### PR TITLE
Update gitea to 1.24.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ octopus-oc-template.version=2.0.2
 #
 bitbucket.image-tag=8.14.0-jdk11
 postgres.image-tag=13-alpine
-gitea.image-tag=1.24.3-rootless
+gitea.image-tag=1.24.4-rootless
 opensearch.image-tag=2.11.1
 #
 test.platform=docker


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Gitea Docker image used in the build/test environment to 1.24.4-rootless.
  * Aligns CI tooling with the latest patch release for improved stability and security.
  * No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->