### PR TITLE
Change version suffix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ val defaultVersion = "${
         update(InetAddress.getLocalHost().hostName.toByteArray())
         value
     }
-}-snapshot"
+}-SNAPSHOT"
 
 allprojects {
     group = "org.octopusden.octopus.vcsfacade"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the casing of the snapshot version suffix, ensuring consistent version labeling across builds, artifact names, and displayed app/version metadata.

* **Chores**
  * Standardized default build output to use the “-SNAPSHOT” suffix when no explicit version is provided, aligning version strings across environments and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->