### PR TITLE
Strip /scm/ prefix from Bitbucket SSH URLs to fix REST API path resolution

### DIFF
--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsService.kt
@@ -11,6 +11,7 @@ import org.octopusden.octopus.vcsfacade.client.common.dto.Repository
 import org.octopusden.octopus.vcsfacade.client.common.dto.Tag
 import org.octopusden.octopus.vcsfacade.config.VcsProperties
 import org.octopusden.octopus.vcsfacade.dto.HashOrRefOrDate
+import org.octopusden.octopus.vcsfacade.dto.VcsServiceType
 
 abstract class VcsService(vcsServiceProperties: VcsProperties.Service) {
     val id = vcsServiceProperties.id.lowercase()
@@ -18,7 +19,7 @@ abstract class VcsService(vcsServiceProperties: VcsProperties.Service) {
     val indexing = vcsServiceProperties.indexing
     protected val httpUrl = vcsServiceProperties.httpUrl.lowercase().trimEnd('/')
     protected val sshUrl = vcsServiceProperties.sshUrl.lowercase().trimEnd(':', '/')
-    private val sshUrlRegex = "${Regex.escape(sshUrl)}[:/](?:scm/)?((?:[^/]+/)+)([^/]+)\\.git".toRegex()
+    private val sshUrlRegex = "${Regex.escape(sshUrl)}[:/]${if (type == VcsServiceType.BITBUCKET) "(?:scm/)?" else ""}((?:[^/]+/)+)([^/]+)\\.git".toRegex()
     fun isSupported(sshUrl: String) = sshUrlRegex.matches(sshUrl.lowercase())
     fun parse(sshUrl: String) = sshUrlRegex.find(sshUrl.lowercase())!!.destructured.let {
         it.component1().trimEnd('/') to it.component2()

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsService.kt
@@ -18,7 +18,7 @@ abstract class VcsService(vcsServiceProperties: VcsProperties.Service) {
     val indexing = vcsServiceProperties.indexing
     protected val httpUrl = vcsServiceProperties.httpUrl.lowercase().trimEnd('/')
     protected val sshUrl = vcsServiceProperties.sshUrl.lowercase().trimEnd(':', '/')
-    private val sshUrlRegex = "$sshUrl[:/]((?:[^/]+/)+)([^/]+).git".toRegex()
+    private val sshUrlRegex = "$sshUrl[:/](?:scm/)?((?:[^/]+/)+)([^/]+)\\.git".toRegex()
     fun isSupported(sshUrl: String) = sshUrlRegex.matches(sshUrl.lowercase())
     fun parse(sshUrl: String) = sshUrlRegex.find(sshUrl.lowercase())!!.destructured.let {
         it.component1().trimEnd('/') to it.component2()

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsService.kt
@@ -18,7 +18,7 @@ abstract class VcsService(vcsServiceProperties: VcsProperties.Service) {
     val indexing = vcsServiceProperties.indexing
     protected val httpUrl = vcsServiceProperties.httpUrl.lowercase().trimEnd('/')
     protected val sshUrl = vcsServiceProperties.sshUrl.lowercase().trimEnd(':', '/')
-    private val sshUrlRegex = "$sshUrl[:/](?:scm/)?((?:[^/]+/)+)([^/]+)\\.git".toRegex()
+    private val sshUrlRegex = "${Regex.escape(sshUrl)}[:/](?:scm/)?((?:[^/]+/)+)([^/]+)\\.git".toRegex()
     fun isSupported(sshUrl: String) = sshUrlRegex.matches(sshUrl.lowercase())
     fun parse(sshUrl: String) = sshUrlRegex.find(sshUrl.lowercase())!!.destructured.let {
         it.component1().trimEnd('/') to it.component2()

--- a/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/service/VcsServiceSshUrlParsingTest.kt
+++ b/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/service/VcsServiceSshUrlParsingTest.kt
@@ -1,0 +1,119 @@
+package org.octopusden.octopus.vcsfacade.service
+
+import java.util.Date
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.vcsfacade.client.common.dto.Branch
+import org.octopusden.octopus.vcsfacade.client.common.dto.Commit
+import org.octopusden.octopus.vcsfacade.client.common.dto.CommitWithFiles
+import org.octopusden.octopus.vcsfacade.client.common.dto.CreatePullRequest
+import org.octopusden.octopus.vcsfacade.client.common.dto.CreateTag
+import org.octopusden.octopus.vcsfacade.client.common.dto.PullRequest
+import org.octopusden.octopus.vcsfacade.client.common.dto.Repository
+import org.octopusden.octopus.vcsfacade.client.common.dto.Tag
+import org.octopusden.octopus.vcsfacade.config.VcsProperties
+import org.octopusden.octopus.vcsfacade.dto.HashOrRefOrDate
+import org.octopusden.octopus.vcsfacade.dto.VcsServiceType
+
+class VcsServiceSshUrlParsingTest {
+
+    private fun createService(sshUrl: String, type: VcsServiceType): VcsService {
+        val properties = VcsProperties.Service(
+            id = "test",
+            type = type,
+            httpUrl = "http://localhost",
+            sshUrl = sshUrl,
+            token = "test-token",
+            username = null,
+            password = null,
+            healthCheck = null
+        )
+        return object : VcsService(properties) {
+            override fun getRepositories(): Sequence<Repository> = TODO()
+            override fun findRepository(group: String, repository: String): Repository? = TODO()
+            override fun getBranches(group: String, repository: String): Sequence<Branch> = TODO()
+            override fun getTags(group: String, repository: String): Sequence<Tag> = TODO()
+            override fun createTag(group: String, repository: String, createTag: CreateTag): Tag = TODO()
+            override fun getTag(group: String, repository: String, name: String): Tag = TODO()
+            override fun deleteTag(group: String, repository: String, name: String) = TODO()
+            override fun getCommits(group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String): Sequence<Commit> = TODO()
+            override fun getCommitsWithFiles(group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String): Sequence<CommitWithFiles> = TODO()
+            override fun getBranchesCommitGraph(group: String, repository: String): Sequence<CommitWithFiles> = TODO()
+            override fun getCommit(group: String, repository: String, hashOrRef: String): Commit = TODO()
+            override fun getCommitWithFiles(group: String, repository: String, hashOrRef: String): CommitWithFiles = TODO()
+            override fun getPullRequests(group: String, repository: String): Sequence<PullRequest> = TODO()
+            override fun createPullRequest(group: String, repository: String, createPullRequest: CreatePullRequest): PullRequest = TODO()
+            override fun getPullRequest(group: String, repository: String, index: Long): PullRequest = TODO()
+            override fun findTags(group: String, repository: String, names: Set<String>): Sequence<Tag> = TODO()
+            override fun findCommits(group: String, repository: String, hashes: Set<String>): Sequence<Commit> = TODO()
+            override fun findPullRequests(group: String, repository: String, indexes: Set<Long>): Sequence<PullRequest> = TODO()
+            override fun findBranches(issueKey: String): Sequence<Branch> = TODO()
+            override fun findCommits(issueKey: String): Sequence<Commit> = TODO()
+            override fun findCommitsWithFiles(issueKey: String): Sequence<CommitWithFiles> = TODO()
+            override fun findPullRequests(issueKey: String): Sequence<PullRequest> = TODO()
+        }
+    }
+
+    private val bitbucketService = createService("ssh://git@bitbucket.example.com", VcsServiceType.BITBUCKET)
+    private val giteaService = createService("ssh://git@gitea.example.com", VcsServiceType.GITEA)
+
+    @Test
+    fun `bitbucket parse standard SSH URL`() {
+        val (group, repository) = bitbucketService.parse("ssh://git@bitbucket.example.com/project/repo.git")
+        assertEquals("project", group)
+        assertEquals("repo", repository)
+    }
+
+    @Test
+    fun `bitbucket parse SSH URL with scm prefix`() {
+        val (group, repository) = bitbucketService.parse("ssh://git@bitbucket.example.com/scm/project/repo.git")
+        assertEquals("project", group)
+        assertEquals("repo", repository)
+    }
+
+    @Test
+    fun `bitbucket isSupported for standard URL`() {
+        assertTrue(bitbucketService.isSupported("ssh://git@bitbucket.example.com/project/repo.git"))
+    }
+
+    @Test
+    fun `bitbucket isSupported for URL with scm prefix`() {
+        assertTrue(bitbucketService.isSupported("ssh://git@bitbucket.example.com/scm/project/repo.git"))
+    }
+
+    @Test
+    fun `bitbucket isSupported returns false for different host`() {
+        assertFalse(bitbucketService.isSupported("ssh://git@other-host.com/project/repo.git"))
+    }
+
+    @Test
+    fun `gitea parse standard SSH URL`() {
+        val (group, repository) = giteaService.parse("ssh://git@gitea.example.com/org/repo.git")
+        assertEquals("org", group)
+        assertEquals("repo", repository)
+    }
+
+    @Test
+    fun `gitea parse SSH URL with org named scm`() {
+        val (group, repository) = giteaService.parse("ssh://git@gitea.example.com/scm/repo.git")
+        assertEquals("scm", group)
+        assertEquals("repo", repository)
+    }
+
+    @Test
+    fun `gitea isSupported for standard URL`() {
+        assertTrue(giteaService.isSupported("ssh://git@gitea.example.com/org/repo.git"))
+    }
+
+    @Test
+    fun `gitea isSupported returns false for different host`() {
+        assertFalse(giteaService.isSupported("ssh://git@bitbucket.example.com/project/repo.git"))
+    }
+
+    @Test
+    fun `isSupported does not match host with dots as wildcards`() {
+        assertFalse(bitbucketService.isSupported("ssh://git@bitbucketXexampleYcom/project/repo.git"))
+    }
+}

--- a/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/service/VcsServiceSshUrlParsingTest.kt
+++ b/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/service/VcsServiceSshUrlParsingTest.kt
@@ -30,30 +30,7 @@ class VcsServiceSshUrlParsingTest {
             password = null,
             healthCheck = null
         )
-        return object : VcsService(properties) {
-            override fun getRepositories(): Sequence<Repository> = TODO()
-            override fun findRepository(group: String, repository: String): Repository? = TODO()
-            override fun getBranches(group: String, repository: String): Sequence<Branch> = TODO()
-            override fun getTags(group: String, repository: String): Sequence<Tag> = TODO()
-            override fun createTag(group: String, repository: String, createTag: CreateTag): Tag = TODO()
-            override fun getTag(group: String, repository: String, name: String): Tag = TODO()
-            override fun deleteTag(group: String, repository: String, name: String) = TODO()
-            override fun getCommits(group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String): Sequence<Commit> = TODO()
-            override fun getCommitsWithFiles(group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String): Sequence<CommitWithFiles> = TODO()
-            override fun getBranchesCommitGraph(group: String, repository: String): Sequence<CommitWithFiles> = TODO()
-            override fun getCommit(group: String, repository: String, hashOrRef: String): Commit = TODO()
-            override fun getCommitWithFiles(group: String, repository: String, hashOrRef: String): CommitWithFiles = TODO()
-            override fun getPullRequests(group: String, repository: String): Sequence<PullRequest> = TODO()
-            override fun createPullRequest(group: String, repository: String, createPullRequest: CreatePullRequest): PullRequest = TODO()
-            override fun getPullRequest(group: String, repository: String, index: Long): PullRequest = TODO()
-            override fun findTags(group: String, repository: String, names: Set<String>): Sequence<Tag> = TODO()
-            override fun findCommits(group: String, repository: String, hashes: Set<String>): Sequence<Commit> = TODO()
-            override fun findPullRequests(group: String, repository: String, indexes: Set<Long>): Sequence<PullRequest> = TODO()
-            override fun findBranches(issueKey: String): Sequence<Branch> = TODO()
-            override fun findCommits(issueKey: String): Sequence<Commit> = TODO()
-            override fun findCommitsWithFiles(issueKey: String): Sequence<CommitWithFiles> = TODO()
-            override fun findPullRequests(issueKey: String): Sequence<PullRequest> = TODO()
-        }
+        return StubVcsService(properties)
     }
 
     private val bitbucketService = createService("ssh://git@bitbucket.example.com", VcsServiceType.BITBUCKET)
@@ -113,7 +90,39 @@ class VcsServiceSshUrlParsingTest {
     }
 
     @Test
+    fun `gitea parse SCP-style URL with colon`() {
+        val (group, repository) = giteaService.parse("ssh://git@gitea.example.com:org/repo.git")
+        assertEquals("org", group)
+        assertEquals("repo", repository)
+    }
+
+    @Test
     fun `isSupported does not match host with dots as wildcards`() {
         assertFalse(bitbucketService.isSupported("ssh://git@bitbucketXexampleYcom/project/repo.git"))
+    }
+
+    private class StubVcsService(properties: VcsProperties.Service) : VcsService(properties) {
+        override fun getRepositories(): Sequence<Repository> = TODO()
+        override fun findRepository(group: String, repository: String): Repository? = TODO()
+        override fun getBranches(group: String, repository: String): Sequence<Branch> = TODO()
+        override fun getTags(group: String, repository: String): Sequence<Tag> = TODO()
+        override fun createTag(group: String, repository: String, createTag: CreateTag): Tag = TODO()
+        override fun getTag(group: String, repository: String, name: String): Tag = TODO()
+        override fun deleteTag(group: String, repository: String, name: String) = TODO()
+        override fun getCommits(group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String): Sequence<Commit> = TODO()
+        override fun getCommitsWithFiles(group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String): Sequence<CommitWithFiles> = TODO()
+        override fun getBranchesCommitGraph(group: String, repository: String): Sequence<CommitWithFiles> = TODO()
+        override fun getCommit(group: String, repository: String, hashOrRef: String): Commit = TODO()
+        override fun getCommitWithFiles(group: String, repository: String, hashOrRef: String): CommitWithFiles = TODO()
+        override fun getPullRequests(group: String, repository: String): Sequence<PullRequest> = TODO()
+        override fun createPullRequest(group: String, repository: String, createPullRequest: CreatePullRequest): PullRequest = TODO()
+        override fun getPullRequest(group: String, repository: String, index: Long): PullRequest = TODO()
+        override fun findTags(group: String, repository: String, names: Set<String>): Sequence<Tag> = TODO()
+        override fun findCommits(group: String, repository: String, hashes: Set<String>): Sequence<Commit> = TODO()
+        override fun findPullRequests(group: String, repository: String, indexes: Set<Long>): Sequence<PullRequest> = TODO()
+        override fun findBranches(issueKey: String): Sequence<Branch> = TODO()
+        override fun findCommits(issueKey: String): Sequence<Commit> = TODO()
+        override fun findCommitsWithFiles(issueKey: String): Sequence<CommitWithFiles> = TODO()
+        override fun findPullRequests(issueKey: String): Sequence<PullRequest> = TODO()
     }
 }


### PR DESCRIPTION
  ## Summary
  - Fix SSH URL regex to strip optional `/scm/` prefix from Bitbucket Server SSH URLs
  - Escape `.` before `git` in regex to match literal dot only

  ## Problem
  Bitbucket Server SSH URLs may contain `/scm/` in the path (e.g., `ssh://git@host/scm/project/repo.git`). The previous regex captured `scm/` as part of the project key, resulting
  in malformed REST API calls like `/rest/api/1.0/projects/scm/project/repos/repo/commits`. Bitbucket returns an HTML error page for this invalid path, which Feign fails to parse as
   JSON:

  Unexpected character ('<' (code 60)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')

  ## Fix
  Changed the SSH URL regex from:
  $sshUrl[:/]((?:[^/]+/)+)([^/]+).git
  To:
  $sshUrl[:/](?:scm/)?((?:[^/]+/)+)([^/]+)\.git

  `(?:scm/)?` optionally matches and discards the `/scm/` segment before capture groups. This fixes all endpoints that rely on `parse()` (`getIssuesFromCommits`, `getCommits`,
  `getTags`, etc.). URLs without `/scm/` are unaffected. Gitea URLs are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git SSH URL recognition and parsing: stricter host matching, literal ".git" enforcement, and optional intermediate path segment limited to the Bitbucket format to reduce false matches.
* **Tests**
  * Added unit tests validating SSH URL parsing and support-detection, including edge cases for host matching and presence/absence of the intermediate path segment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->