### PR TITLE
Add init container to wait for Postgres readiness before Bitbucket startup

### DIFF
--- a/okd/bitbucket.yaml
+++ b/okd/bitbucket.yaml
@@ -104,6 +104,10 @@ objects:
     initContainers:
       - name: wait-for-db
         image: ${DOCKER_REGISTRY}/postgres:${POSTGRES_IMAGE_TAG}
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "32Mi"
         command:
           - sh
           - -c

--- a/okd/bitbucket.yaml
+++ b/okd/bitbucket.yaml
@@ -101,6 +101,13 @@ objects:
   spec:
     restartPolicy: Never
     activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+    initContainers:
+      - name: wait-for-db
+        image: ${DOCKER_REGISTRY}/postgres:${POSTGRES_IMAGE_TAG}
+        command:
+          - sh
+          - -c
+          - until pg_isready -h ${DEPLOYMENT_PREFIX}-bitbucket-db-service -p 5432 -U bitbucket; do echo "Waiting for DB..."; sleep 2; done
     containers:
       - name: bitbucket
         image: ${DOCKER_REGISTRY}/atlassian/bitbucket:${BITBUCKET_IMAGE_TAG}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment stability by implementing a database readiness check. Bitbucket now waits for database connectivity confirmation before startup, reducing potential initialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->