### PR TITLE
Update Gitea to 1.26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ octopus-oc-template.version=2.0.7
 #
 bitbucket.image-tag=9.4.13
 postgres.image-tag=17-alpine
-gitea.image-tag=1.26.1-rootless
+gitea.image-tag=1.26.2-rootless
 opensearch.image-tag=2.11.1
 #
 test.platform=docker


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gitea image version from 1.26.1-rootless to 1.26.2-rootless.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->