### PR TITLE
ci: adopt octopusden quality-gates (Phase 4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,17 @@
+# INTERNAL — runs on push to main, on manual dispatch, and as a workflow_call unit of the Merge Gate.
 name: Gradle Compile & UT
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'
       docker-image: vcs-facade
+    secrets: inherit

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/vcsfacade/vcs-facade/_VER_/vcs-facade-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/vcsfacade/vcs-facade/_VER_/vcs-facade-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/vcsfacade/vcs-facade/_VER_/vcs-facade-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,34 @@
+# PUBLIC — every PR triggers this workflow and the gate/merge check must be green to merge.
+name: Merge Gate
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  quality:
+    uses: ./.github/workflows/quality.yml
+    secrets: inherit
+
+  security:
+    uses: ./.github/workflows/security.yml
+    secrets: inherit
+
+  gate-merge:
+    name: gate/merge
+    needs: [ build, quality, security ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+        with:
+          needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,15 @@
+# INTERNAL — runs on push to main, on manual dispatch, and as a workflow_call unit of the Merge Gate.
+name: Quality
+
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  quality:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    with:
+      java-version: '21'
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.7
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,17 @@
+# INTERNAL — runs on push to main, weekly, on manual dispatch, and as a workflow_call unit of the Merge Gate.
+name: Security
+
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'   # every Monday at 03:00 UTC
+
+jobs:
+  security:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    with:
+      java-version: '21'
+    secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
     with:
       java-version: '21'
     secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,25 @@ plugins {
     id("org.jetbrains.kotlin.jvm")
     id("io.github.gradle-nexus.publish-plugin")
     signing
+    // Kotlin static-analysis tools — declared at root (apply false), applied per Kotlin subproject below.
+    id("io.gitlab.arturbosch.detekt") apply (false)
+    id("org.jlleitschuh.gradle.ktlint") apply (false)
+    // Octopus quality-gates convention plugin — configures detekt/ktlint and wires qualityStatic.
+    id("org.octopusden.octopus-quality")
+}
+
+octopusQuality {
+    // Repo has no coverage tool / no unit-test coverage target — disable coverage verification.
+    coverage {
+        enabled.set(false)
+    }
+    // Enforce the gate: detekt/ktlint violations fail the build. Current debt is absorbed by
+    // the committed detekt-baseline.xml / ktlint-baseline.xml files.
+    kotlin {
+        failOnViolation.set(true)
+    }
+    // Functional-test tasks are excluded from the quality gate.
+    excludeTasks("ft", ":ft:ft")
 }
 
 val defaultVersion = "${
@@ -48,6 +67,23 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "signing")
+    // Kotlin static analysis — must be applied per subproject so the convention plugin's
+    // reactive configuration wires detekt/ktlintCheck tasks (avoids a hollow quality gate).
+    apply(plugin = "io.gitlab.arturbosch.detekt")
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+
+    // detekt 1.23.8 bundles kotlin-compiler-embeddable 2.0.21. The Spring
+    // dependency-management BOM (imported below) constrains every configuration —
+    // including detekt's — and would otherwise downgrade it to the project Kotlin
+    // (1.9.22), which detekt rejects ("compiled with Kotlin 2.0.21 but running with
+    // 1.9.22"). Pin only the detekt configuration back to detekt's bundled version.
+    configurations.matching { it.name == "detekt" }.configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.jetbrains.kotlin") {
+                useVersion("2.0.21")
+            }
+        }
+    }
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,11 @@ octopusQuality {
         failOnViolation.set(true)
     }
     // Functional-test tasks are excluded from the quality gate.
-    excludeTasks("ft", ":ft:ft")
+    // :vcs-facade:test is an infra-bound integration test: docker-compose (test.platform=docker)
+    // wires composeBuild/composeUp onto it via dockerCompose.isRequiredBy(test), which cannot run
+    // on the GitHub runner (no docker-compose / no OKD). Coverage is disabled for this repo, so the
+    // qualityCoverage aggregate must not pull this task (and its compose chain) into the graph.
+    excludeTasks("ft", ":ft:ft", ":vcs-facade:test")
 }
 
 val defaultVersion = "${

--- a/client/detekt-baseline.xml
+++ b/client/detekt-baseline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaxLineLength:VcsFacadeClient.kt$VcsFacadeClient$"GET rest/api/2/repository/commits/files?sshUrl={sshUrl}&amp;fromHashOrRef={fromHashOrRef}&amp;fromDate={fromDate}&amp;toHashOrRef={toHashOrRef}&amp;commitFilesLimit={commitFilesLimit}"</ID>
+    <ID>SwallowedException:VcsFacadeErrorDecoder.kt$VcsFacadeErrorDecoder$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:VcsFacadeErrorDecoder.kt$VcsFacadeErrorDecoder$e: Exception</ID>
+    <ID>TooManyFunctions:ClassicVcsFacadeClient.kt$ClassicVcsFacadeClient : VcsFacadeClient</ID>
+    <ID>TooManyFunctions:VcsFacadeClient.kt$VcsFacadeClient</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/client/ktlint-baseline.xml
+++ b/client/ktlint-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+</baseline>

--- a/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/DateToISOExpander.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/DateToISOExpander.kt
@@ -6,13 +6,17 @@ import java.time.format.DateTimeFormatter
 import java.util.Date
 
 class DateToISOExpander : Param.Expander {
-    override fun expand(value: Any?) = if (value == null) "" else {
-        (value as? Date)?.let { FORMATTER.format(it.toInstant()) }
-            ?: throw IllegalArgumentException("Value must be as java.util.Date but was '${value::class.qualifiedName}'")
-    }
+    override fun expand(value: Any?) =
+        if (value == null) {
+            ""
+        } else {
+            (value as? Date)?.let { FORMATTER.format(it.toInstant()) }
+                ?: throw IllegalArgumentException("Value must be as java.util.Date but was '${value::class.qualifiedName}'")
+        }
 
     companion object {
-        private val FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+        private val FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
             .withZone(ZoneId.systemDefault())
     }
 }

--- a/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/VcsFacadeClient.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/VcsFacadeClient.kt
@@ -3,7 +3,6 @@ package org.octopusden.octopus.vcsfacade.client
 import feign.Headers
 import feign.Param
 import feign.RequestLine
-import java.util.Date
 import org.octopusden.octopus.vcsfacade.client.common.dto.Branch
 import org.octopusden.octopus.vcsfacade.client.common.dto.Commit
 import org.octopusden.octopus.vcsfacade.client.common.dto.CommitWithFiles
@@ -15,55 +14,77 @@ import org.octopusden.octopus.vcsfacade.client.common.dto.SearchIssueInRangesRes
 import org.octopusden.octopus.vcsfacade.client.common.dto.SearchIssuesInRangesRequest
 import org.octopusden.octopus.vcsfacade.client.common.dto.SearchSummary
 import org.octopusden.octopus.vcsfacade.client.common.dto.Tag
+import java.util.Date
 
 interface VcsFacadeClient {
-    @RequestLine("GET rest/api/2/repository/commits?sshUrl={sshUrl}&fromHashOrRef={fromHashOrRef}&fromDate={fromDate}&toHashOrRef={toHashOrRef}")
+    @RequestLine(
+        "GET rest/api/2/repository/commits?sshUrl={sshUrl}&fromHashOrRef={fromHashOrRef}&fromDate={fromDate}&toHashOrRef={toHashOrRef}",
+    )
     fun getCommits(
         @Param("sshUrl") sshUrl: String,
         @Param("fromHashOrRef") fromHashOrRef: String?,
         @Param("fromDate", expander = DateToISOExpander::class) fromDate: Date?,
-        @Param("toHashOrRef") toHashOrRef: String
+        @Param("toHashOrRef") toHashOrRef: String,
     ): List<Commit>
 
-    @RequestLine("GET rest/api/2/repository/commits/files?sshUrl={sshUrl}&fromHashOrRef={fromHashOrRef}&fromDate={fromDate}&toHashOrRef={toHashOrRef}&commitFilesLimit={commitFilesLimit}")
+    @RequestLine(
+        "GET rest/api/2/repository/commits/files?sshUrl={sshUrl}&fromHashOrRef={fromHashOrRef}&fromDate={fromDate}&toHashOrRef={toHashOrRef}&commitFilesLimit={commitFilesLimit}",
+    )
     fun getCommitsWithFiles(
         @Param("sshUrl") sshUrl: String,
         @Param("fromHashOrRef") fromHashOrRef: String?,
         @Param("fromDate", expander = DateToISOExpander::class) fromDate: Date?,
         @Param("toHashOrRef") toHashOrRef: String,
-        @Param("commitFilesLimit") commitFilesLimit: Int?
+        @Param("commitFilesLimit") commitFilesLimit: Int?,
     ): List<CommitWithFiles>
 
     @RequestLine("GET rest/api/2/repository/commit?sshUrl={sshUrl}&hashOrRef={hashOrRef}")
-    fun getCommit(@Param("sshUrl") sshUrl: String, @Param("hashOrRef") hashOrRef: String): Commit
+    fun getCommit(
+        @Param("sshUrl") sshUrl: String,
+        @Param("hashOrRef") hashOrRef: String,
+    ): Commit
 
     @RequestLine("GET rest/api/2/repository/commit/files?sshUrl={sshUrl}&hashOrRef={hashOrRef}&commitFilesLimit={commitFilesLimit}")
     fun getCommitWithFiles(
         @Param("sshUrl") sshUrl: String,
         @Param("hashOrRef") hashOrRef: String,
-        @Param("commitFilesLimit") commitFilesLimit: Int?
+        @Param("commitFilesLimit") commitFilesLimit: Int?,
     ): CommitWithFiles
 
-    @RequestLine("GET rest/api/2/repository/issues?sshUrl={sshUrl}&fromHashOrRef={fromHashOrRef}&fromDate={fromDate}&toHashOrRef={toHashOrRef}")
+    @RequestLine(
+        "GET rest/api/2/repository/issues?sshUrl={sshUrl}&fromHashOrRef={fromHashOrRef}&fromDate={fromDate}&toHashOrRef={toHashOrRef}",
+    )
     fun getIssuesFromCommits(
         @Param("sshUrl") sshUrl: String,
         @Param("fromHashOrRef") fromHashOrRef: String?,
         @Param("fromDate", expander = DateToISOExpander::class) fromDate: Date?,
-        @Param("toHashOrRef") toHashOrRef: String
+        @Param("toHashOrRef") toHashOrRef: String,
     ): List<String>
 
     @RequestLine("GET rest/api/2/repository/tags?sshUrl={sshUrl}&names={names}")
-    fun getTags(@Param("sshUrl") sshUrl: String, @Param("names") names: Set<String>? = null): List<Tag>
+    fun getTags(
+        @Param("sshUrl") sshUrl: String,
+        @Param("names") names: Set<String>? = null,
+    ): List<Tag>
 
     @RequestLine("POST rest/api/2/repository/tags?sshUrl={sshUrl}")
     @Headers("Content-Type: application/json")
-    fun createTag(@Param("sshUrl") sshUrl: String, createTag: CreateTag): Tag
+    fun createTag(
+        @Param("sshUrl") sshUrl: String,
+        createTag: CreateTag,
+    ): Tag
 
     @RequestLine("GET rest/api/2/repository/tag?sshUrl={sshUrl}&name={name}")
-    fun getTag(@Param("sshUrl") sshUrl: String, @Param("name") name: String): Tag
+    fun getTag(
+        @Param("sshUrl") sshUrl: String,
+        @Param("name") name: String,
+    ): Tag
 
     @RequestLine("DELETE rest/api/2/repository/tag?sshUrl={sshUrl}&name={name}")
-    fun deleteTag(@Param("sshUrl") sshUrl: String, @Param("name") name: String)
+    fun deleteTag(
+        @Param("sshUrl") sshUrl: String,
+        @Param("name") name: String,
+    )
 
     @RequestLine("POST rest/api/2/repository/search-issues-in-ranges")
     @Headers("Content-Type: application/json")
@@ -71,29 +92,44 @@ interface VcsFacadeClient {
 
     @RequestLine("POST rest/api/2/repository/pull-requests?sshUrl={sshUrl}")
     @Headers("Content-Type: application/json")
-    fun createPullRequest(@Param("sshUrl") sshUrl: String, createPullRequest: CreatePullRequest): PullRequest
+    fun createPullRequest(
+        @Param("sshUrl") sshUrl: String,
+        createPullRequest: CreatePullRequest,
+    ): PullRequest
 
     @RequestLine("GET rest/api/2/repository/find?issueKeys={issueKeys}")
-    fun findByIssueKeys(@Param("issueKeys") issueKeys: Set<String>): SearchSummary
+    fun findByIssueKeys(
+        @Param("issueKeys") issueKeys: Set<String>,
+    ): SearchSummary
 
     @RequestLine("GET rest/api/2/repository/branches/find?issueKeys={issueKeys}")
-    fun findBranchesByIssueKeys(@Param("issueKeys") issueKeys: Set<String>): List<Branch>
+    fun findBranchesByIssueKeys(
+        @Param("issueKeys") issueKeys: Set<String>,
+    ): List<Branch>
 
     @RequestLine("GET rest/api/2/repository/commits/find?issueKeys={issueKeys}")
-    fun findCommitsByIssueKeys(@Param("issueKeys") issueKeys: Set<String>): List<Commit>
+    fun findCommitsByIssueKeys(
+        @Param("issueKeys") issueKeys: Set<String>,
+    ): List<Commit>
 
     @RequestLine("GET rest/api/2/repository/commits/files/find?issueKeys={issueKeys}&commitFilesLimit={commitFilesLimit}")
     fun findCommitsWithFilesByIssueKeys(
         @Param("issueKeys") issueKeys: Set<String>,
-        @Param("commitFilesLimit") commitFilesLimit: Int?
+        @Param("commitFilesLimit") commitFilesLimit: Int?,
     ): List<CommitWithFiles>
 
     @RequestLine("GET rest/api/2/repository/pull-requests/find?issueKeys={issueKeys}")
-    fun findPullRequestsByIssueKeys(@Param("issueKeys") issueKeys: Set<String>): List<PullRequest>
+    fun findPullRequestsByIssueKeys(
+        @Param("issueKeys") issueKeys: Set<String>,
+    ): List<PullRequest>
 
     @RequestLine("POST rest/api/1/indexer/scan?sshUrl={sshUrl}")
-    fun reindexRepository(@Param("sshUrl") sshUrl: String)
+    fun reindexRepository(
+        @Param("sshUrl") sshUrl: String,
+    )
 
     @RequestLine("GET rest/api/1/indexer/report?scanRequired={scanRequired}")
-    fun indexReport(@Param("scanRequired") scanRequired: Boolean? = null): IndexReport
+    fun indexReport(
+        @Param("scanRequired") scanRequired: Boolean? = null,
+    ): IndexReport
 }

--- a/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/VcsFacadeErrorDecoder.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/VcsFacadeErrorDecoder.kt
@@ -5,20 +5,29 @@ import feign.Response
 import feign.codec.ErrorDecoder
 import org.octopusden.octopus.vcsfacade.client.common.dto.ErrorResponse
 
-class VcsFacadeErrorDecoder(private val objectMapper: ObjectMapper) : ErrorDecoder.Default() {
-    override fun decode(methodKey: String?, response: Response?): Exception {
-        return getErrorResponse(response)?.let {
+class VcsFacadeErrorDecoder(
+    private val objectMapper: ObjectMapper,
+) : ErrorDecoder.Default() {
+    override fun decode(
+        methodKey: String?,
+        response: Response?,
+    ): Exception =
+        getErrorResponse(response)?.let {
             it.errorCode.getException(it.errorMessage)
         } ?: super.decode(methodKey, response)
-    }
 
-    private fun getErrorResponse(response: Response?) = if (response != null) {
-        if (response.headers()["content-type"]?.find { header -> header.contains("application/json") } != null) {
-            try {
-                response.body()?.asInputStream()?.use { objectMapper.readValue(it, ErrorResponse::class.java) }
-            } catch (e: Exception) {
+    private fun getErrorResponse(response: Response?) =
+        if (response != null) {
+            if (response.headers()["content-type"]?.find { header -> header.contains("application/json") } != null) {
+                try {
+                    response.body()?.asInputStream()?.use { objectMapper.readValue(it, ErrorResponse::class.java) }
+                } catch (e: Exception) {
+                    null
+                }
+            } else {
                 null
             }
-        } else null
-    } else null
+        } else {
+            null
+        }
 }

--- a/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/VcsFacadeResponseInterceptor.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/VcsFacadeResponseInterceptor.kt
@@ -8,26 +8,30 @@ import org.apache.http.HttpStatus
 import org.octopusden.octopus.vcsfacade.client.common.Constants
 import org.octopusden.octopus.vcsfacade.client.common.dto.RetryResponse
 
-class VcsFacadeResponseInterceptor(private val objectMapper: ObjectMapper) : ResponseInterceptor {
-    override fun intercept(invocationContext: InvocationContext?, chain: ResponseInterceptor.Chain) =
-        invocationContext?.let {
-            with(it.response()) {
-                if (status() == HttpStatus.SC_ACCEPTED) {
-                    val retryResponse = body().asInputStream().use { inputStream ->
-                        objectMapper.readValue(inputStream, RetryResponse::class.java)
-                    }
-                    if (!request().headers().containsKey(Constants.DEFERRED_RESULT_HEADER)) {
-                        request().requestTemplate().header(Constants.DEFERRED_RESULT_HEADER, retryResponse.requestId)
-                    }
-                    throw RetryableException(
-                        HttpStatus.SC_ACCEPTED,
-                        "Waiting for deferred result",
-                        request().httpMethod(),
-                        retryResponse.retryAfter.time,
-                        request()
-                    )
+class VcsFacadeResponseInterceptor(
+    private val objectMapper: ObjectMapper,
+) : ResponseInterceptor {
+    override fun intercept(
+        invocationContext: InvocationContext?,
+        chain: ResponseInterceptor.Chain,
+    ) = invocationContext?.let {
+        with(it.response()) {
+            if (status() == HttpStatus.SC_ACCEPTED) {
+                val retryResponse = body().asInputStream().use { inputStream ->
+                    objectMapper.readValue(inputStream, RetryResponse::class.java)
                 }
+                if (!request().headers().containsKey(Constants.DEFERRED_RESULT_HEADER)) {
+                    request().requestTemplate().header(Constants.DEFERRED_RESULT_HEADER, retryResponse.requestId)
+                }
+                throw RetryableException(
+                    HttpStatus.SC_ACCEPTED,
+                    "Waiting for deferred result",
+                    request().httpMethod(),
+                    retryResponse.retryAfter.time,
+                    request(),
+                )
             }
-            chain.next(it)
         }
+        chain.next(it)
+    }
 }

--- a/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/VcsFacadeRetryer.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/VcsFacadeRetryer.kt
@@ -2,39 +2,40 @@ package org.octopusden.octopus.vcsfacade.client
 
 import feign.RetryableException
 import feign.Retryer
-import java.util.Date
-import java.util.concurrent.TimeUnit
 import org.apache.http.HttpStatus
 import org.slf4j.LoggerFactory
+import java.util.Date
+import java.util.concurrent.TimeUnit
 
-class VcsFacadeRetryer(private val timeRetryInMillis: Int = 60000) : Retryer {
+class VcsFacadeRetryer(
+    private val timeRetryInMillis: Int = 60000,
+) : Retryer {
     private val timeDelayIteration: Int = timeRetryInMillis / NUMBER_ITERATIONS - (NUMBER_ATTEMPTS * TIME_DELAY_ATTEMPT)
     private val stopTime = System.currentTimeMillis() + timeRetryInMillis
     private var attempt: Int = NUMBER_ATTEMPTS
     private var iteration: Int = NUMBER_ITERATIONS
 
     override fun continueOrPropagate(e: RetryableException) {
-        strategies.getOrDefault(e.status()) {
-            if (stopTime < System.currentTimeMillis()) {
-                throw e.cause!!
-            }
-            if (log.isDebugEnabled) {
-                log.debug("Retry: iteration=${NUMBER_ITERATIONS - iteration + 1}, attempt=${NUMBER_ATTEMPTS - attempt + 1}")
-            }
-            if (attempt-- > 0) {
-                TimeUnit.MILLISECONDS.sleep(TIME_DELAY_ATTEMPT.toLong())
-            } else if (iteration-- > 0) {
-                attempt = NUMBER_ATTEMPTS
-                TimeUnit.MILLISECONDS.sleep(timeDelayIteration.toLong())
-            } else {
-                throw e.cause!!
-            }
-        }.invoke(e)
+        strategies
+            .getOrDefault(e.status()) {
+                if (stopTime < System.currentTimeMillis()) {
+                    throw e.cause!!
+                }
+                if (log.isDebugEnabled) {
+                    log.debug("Retry: iteration=${NUMBER_ITERATIONS - iteration + 1}, attempt=${NUMBER_ATTEMPTS - attempt + 1}")
+                }
+                if (attempt-- > 0) {
+                    TimeUnit.MILLISECONDS.sleep(TIME_DELAY_ATTEMPT.toLong())
+                } else if (iteration-- > 0) {
+                    attempt = NUMBER_ATTEMPTS
+                    TimeUnit.MILLISECONDS.sleep(timeDelayIteration.toLong())
+                } else {
+                    throw e.cause!!
+                }
+            }.invoke(e)
     }
 
-    override fun clone(): Retryer {
-        return VcsFacadeRetryer(timeRetryInMillis)
-    }
+    override fun clone(): Retryer = VcsFacadeRetryer(timeRetryInMillis)
 
     companion object {
         private const val NUMBER_ATTEMPTS = 5
@@ -42,15 +43,17 @@ class VcsFacadeRetryer(private val timeRetryInMillis: Int = 60000) : Retryer {
         private const val NUMBER_ITERATIONS = 5
 
         private val log = LoggerFactory.getLogger(VcsFacadeRetryer::class.java)
-        private val strategies = mapOf<Int, (e: RetryableException) -> Unit>(HttpStatus.SC_ACCEPTED to { e ->
-            val currentDate = Date()
-            val retryAfterDate = Date(e.retryAfter())
-            log.debug("Deferred result retry after {}", retryAfterDate)
-            if (retryAfterDate.after(currentDate)) {
-                val sleepingTime = retryAfterDate.time - currentDate.time
-                log.trace("Sleeping time {}ms", sleepingTime)
-                Thread.sleep(sleepingTime)
-            }
-        })
+        private val strategies = mapOf<Int, (e: RetryableException) -> Unit>(
+            HttpStatus.SC_ACCEPTED to { e ->
+                val currentDate = Date()
+                val retryAfterDate = Date(e.retryAfter())
+                log.debug("Deferred result retry after {}", retryAfterDate)
+                if (retryAfterDate.after(currentDate)) {
+                    val sleepingTime = retryAfterDate.time - currentDate.time
+                    log.trace("Sleeping time {}ms", sleepingTime)
+                    Thread.sleep(sleepingTime)
+                }
+            },
+        )
     }
 }

--- a/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/impl/ClassicVcsFacadeClient.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/impl/ClassicVcsFacadeClient.kt
@@ -10,8 +10,6 @@ import feign.httpclient.ApacheHttpClient
 import feign.jackson.JacksonDecoder
 import feign.jackson.JacksonEncoder
 import feign.slf4j.Slf4jLogger
-import java.util.Date
-import java.util.concurrent.TimeUnit
 import org.octopusden.octopus.vcsfacade.client.VcsFacadeClient
 import org.octopusden.octopus.vcsfacade.client.VcsFacadeErrorDecoder
 import org.octopusden.octopus.vcsfacade.client.VcsFacadeResponseInterceptor
@@ -19,50 +17,83 @@ import org.octopusden.octopus.vcsfacade.client.VcsFacadeRetryer
 import org.octopusden.octopus.vcsfacade.client.common.dto.CreatePullRequest
 import org.octopusden.octopus.vcsfacade.client.common.dto.CreateTag
 import org.octopusden.octopus.vcsfacade.client.common.dto.SearchIssuesInRangesRequest
+import java.util.Date
+import java.util.concurrent.TimeUnit
 
 class ClassicVcsFacadeClient(
-    apiParametersProvider: VcsFacadeClientParametersProvider, private val mapper: ObjectMapper
+    apiParametersProvider: VcsFacadeClientParametersProvider,
+    private val mapper: ObjectMapper,
 ) : VcsFacadeClient {
     private var client = createClient(
-        apiParametersProvider.getApiUrl(), mapper, apiParametersProvider.getTimeRetryInMillis()
+        apiParametersProvider.getApiUrl(),
+        mapper,
+        apiParametersProvider.getTimeRetryInMillis(),
     )
 
     constructor(apiParametersProvider: VcsFacadeClientParametersProvider) : this(
-        apiParametersProvider, getMapper()
+        apiParametersProvider,
+        getMapper(),
     )
 
-    override fun getCommits(sshUrl: String, fromHashOrRef: String?, fromDate: Date?, toHashOrRef: String) =
-        client.getCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
+    override fun getCommits(
+        sshUrl: String,
+        fromHashOrRef: String?,
+        fromDate: Date?,
+        toHashOrRef: String,
+    ) = client.getCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
 
     override fun getCommitsWithFiles(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
         toHashOrRef: String,
-        commitFilesLimit: Int?
+        commitFilesLimit: Int?,
     ) = client.getCommitsWithFiles(sshUrl, fromHashOrRef, fromDate, toHashOrRef, commitFilesLimit)
 
-    override fun getCommit(sshUrl: String, hashOrRef: String) = client.getCommit(sshUrl, hashOrRef)
+    override fun getCommit(
+        sshUrl: String,
+        hashOrRef: String,
+    ) = client.getCommit(sshUrl, hashOrRef)
 
-    override fun getCommitWithFiles(sshUrl: String, hashOrRef: String, commitFilesLimit: Int?) =
-        client.getCommitWithFiles(sshUrl, hashOrRef, commitFilesLimit)
+    override fun getCommitWithFiles(
+        sshUrl: String,
+        hashOrRef: String,
+        commitFilesLimit: Int?,
+    ) = client.getCommitWithFiles(sshUrl, hashOrRef, commitFilesLimit)
 
-    override fun getIssuesFromCommits(sshUrl: String, fromHashOrRef: String?, fromDate: Date?, toHashOrRef: String) =
-        client.getIssuesFromCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
+    override fun getIssuesFromCommits(
+        sshUrl: String,
+        fromHashOrRef: String?,
+        fromDate: Date?,
+        toHashOrRef: String,
+    ) = client.getIssuesFromCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
 
-    override fun getTags(sshUrl: String, names: Set<String>?) = client.getTags(sshUrl, names)
+    override fun getTags(
+        sshUrl: String,
+        names: Set<String>?,
+    ) = client.getTags(sshUrl, names)
 
-    override fun createTag(sshUrl: String, createTag: CreateTag) = client.createTag(sshUrl, createTag)
+    override fun createTag(
+        sshUrl: String,
+        createTag: CreateTag,
+    ) = client.createTag(sshUrl, createTag)
 
-    override fun getTag(sshUrl: String, name: String) = client.getTag(sshUrl, name)
+    override fun getTag(
+        sshUrl: String,
+        name: String,
+    ) = client.getTag(sshUrl, name)
 
-    override fun deleteTag(sshUrl: String, name: String) = client.deleteTag(sshUrl, name)
+    override fun deleteTag(
+        sshUrl: String,
+        name: String,
+    ) = client.deleteTag(sshUrl, name)
 
-    override fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest) =
-        client.searchIssuesInRanges(searchRequest)
+    override fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest) = client.searchIssuesInRanges(searchRequest)
 
-    override fun createPullRequest(sshUrl: String, createPullRequest: CreatePullRequest) =
-        client.createPullRequest(sshUrl, createPullRequest)
+    override fun createPullRequest(
+        sshUrl: String,
+        createPullRequest: CreatePullRequest,
+    ) = client.createPullRequest(sshUrl, createPullRequest)
 
     override fun findByIssueKeys(issueKeys: Set<String>) = client.findByIssueKeys(issueKeys)
 
@@ -70,8 +101,10 @@ class ClassicVcsFacadeClient(
 
     override fun findCommitsByIssueKeys(issueKeys: Set<String>) = client.findCommitsByIssueKeys(issueKeys)
 
-    override fun findCommitsWithFilesByIssueKeys(issueKeys: Set<String>, commitFilesLimit: Int?) =
-        client.findCommitsWithFilesByIssueKeys(issueKeys, commitFilesLimit)
+    override fun findCommitsWithFilesByIssueKeys(
+        issueKeys: Set<String>,
+        commitFilesLimit: Int?,
+    ) = client.findCommitsWithFilesByIssueKeys(issueKeys, commitFilesLimit)
 
     override fun findPullRequestsByIssueKeys(issueKeys: Set<String>) = client.findPullRequestsByIssueKeys(issueKeys)
 
@@ -80,7 +113,10 @@ class ClassicVcsFacadeClient(
     override fun indexReport(scanRequired: Boolean?) = client.indexReport(scanRequired)
 
     @Suppress("unused")
-    fun setUrl(apiUrl: String, timeRetryInMillis: Int) {
+    fun setUrl(
+        apiUrl: String,
+        timeRetryInMillis: Int,
+    ) {
         client = createClient(apiUrl, mapper, timeRetryInMillis)
     }
 
@@ -91,15 +127,22 @@ class ClassicVcsFacadeClient(
             return objectMapper
         }
 
-        private fun createClient(apiUrl: String, objectMapper: ObjectMapper, timeRetryInMillis: Int): VcsFacadeClient {
-            return Feign.builder().client(ApacheHttpClient())
+        private fun createClient(
+            apiUrl: String,
+            objectMapper: ObjectMapper,
+            timeRetryInMillis: Int,
+        ): VcsFacadeClient =
+            Feign
+                .builder()
+                .client(ApacheHttpClient())
                 .options(Request.Options(30, TimeUnit.SECONDS, 30, TimeUnit.SECONDS, true))
-                .logger(Slf4jLogger(VcsFacadeClient::class.java)).logLevel(Logger.Level.FULL)
+                .logger(Slf4jLogger(VcsFacadeClient::class.java))
+                .logLevel(Logger.Level.FULL)
                 .encoder(JacksonEncoder(objectMapper))
                 .responseInterceptor(VcsFacadeResponseInterceptor(objectMapper))
                 .retryer(VcsFacadeRetryer(timeRetryInMillis))
-                .decoder(JacksonDecoder(objectMapper)).errorDecoder(VcsFacadeErrorDecoder(objectMapper))
+                .decoder(JacksonDecoder(objectMapper))
+                .errorDecoder(VcsFacadeErrorDecoder(objectMapper))
                 .target(VcsFacadeClient::class.java, apiUrl)
-        }
     }
 }

--- a/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/impl/VcsFacadeClientParametersProvider.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/impl/VcsFacadeClientParametersProvider.kt
@@ -2,5 +2,6 @@ package org.octopusden.octopus.vcsfacade.client.impl
 
 interface VcsFacadeClientParametersProvider {
     fun getApiUrl(): String
+
     fun getTimeRetryInMillis(): Int
 }

--- a/common/ktlint-baseline.xml
+++ b/common/ktlint-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+</baseline>

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Branch.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Branch.kt
@@ -1,6 +1,10 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-class Branch(name: String, hash: String, link: String, repository: Repository) :
-    Ref(RefType.BRANCH, name, hash, link, repository) {
+class Branch(
+    name: String,
+    hash: String,
+    link: String,
+    repository: Repository,
+) : Ref(RefType.BRANCH, name, hash, link, repository) {
     override fun toString() = "Branch(name=$name, hash=$hash, link=$link, repository=$repository)"
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Commit.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Commit.kt
@@ -9,8 +9,7 @@ data class Commit(
     val author: User,
     val parents: List<String>,
     val link: String,
-    val repository: Repository
+    val repository: Repository,
 ) : Comparable<Commit> {
-    override fun compareTo(other: Commit) =
-        compareBy(Commit::repository).thenByDescending(Commit::date).compare(this, other)
+    override fun compareTo(other: Commit) = compareBy(Commit::repository).thenByDescending(Commit::date).compare(this, other)
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/CommitWithFiles.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/CommitWithFiles.kt
@@ -3,7 +3,7 @@ package org.octopusden.octopus.vcsfacade.client.common.dto
 data class CommitWithFiles(
     val commit: Commit,
     val totalFiles: Int,
-    val files: List<FileChange>
+    val files: List<FileChange>,
 ) : Comparable<CommitWithFiles> {
     override fun compareTo(other: CommitWithFiles) = commit compareTo other.commit
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/CreatePullRequest.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/CreatePullRequest.kt
@@ -1,5 +1,8 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
 data class CreatePullRequest(
-    val sourceBranch: String, val targetBranch: String, val title: String, val description: String
+    val sourceBranch: String,
+    val targetBranch: String,
+    val title: String,
+    val description: String,
 )

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/CreateTag.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/CreateTag.kt
@@ -1,3 +1,7 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-data class CreateTag(val name: String, val hashOrRef: String, val message: String)
+data class CreateTag(
+    val name: String,
+    val hashOrRef: String,
+    val message: String,
+)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/ErrorResponse.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/ErrorResponse.kt
@@ -1,3 +1,6 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-data class ErrorResponse(val errorCode: VcsFacadeErrorCode, val errorMessage: String)
+data class ErrorResponse(
+    val errorCode: VcsFacadeErrorCode,
+    val errorMessage: String,
+)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/FileChange.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/FileChange.kt
@@ -1,5 +1,9 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-data class FileChange(val type: FileChangeType, val path: String, val link: String) : Comparable<FileChange> {
+data class FileChange(
+    val type: FileChangeType,
+    val path: String,
+    val link: String,
+) : Comparable<FileChange> {
     override fun compareTo(other: FileChange) = path compareTo other.path
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/FileChangeType.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/FileChangeType.kt
@@ -1,5 +1,7 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
 enum class FileChangeType {
-    ADD, MODIFY, DELETE
+    ADD,
+    MODIFY,
+    DELETE,
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/IndexReport.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/IndexReport.kt
@@ -3,7 +3,11 @@ package org.octopusden.octopus.vcsfacade.client.common.dto
 import java.util.Date
 
 data class IndexReport(
-    val repositories: List<IndexReportRepository>
+    val repositories: List<IndexReportRepository>,
 ) {
-    data class IndexReportRepository(val sshUrl: String, val scanRequired: Boolean, val lastScanAt: Date?)
+    data class IndexReportRepository(
+        val sshUrl: String,
+        val scanRequired: Boolean,
+        val lastScanAt: Date?,
+    )
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/PullRequest.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/PullRequest.kt
@@ -15,7 +15,7 @@ data class PullRequest(
     val createdAt: Date,
     val updatedAt: Date,
     val link: String,
-    val repository: Repository
+    val repository: Repository,
 ) : Comparable<PullRequest> {
     override fun compareTo(other: PullRequest) =
         compareBy(PullRequest::repository).thenByDescending(PullRequest::index).compare(this, other)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/PullRequestReviewer.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/PullRequestReviewer.kt
@@ -1,3 +1,6 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-data class PullRequestReviewer(val user: User, val approved: Boolean)
+data class PullRequestReviewer(
+    val user: User,
+    val approved: Boolean,
+)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/PullRequestStatus.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/PullRequestStatus.kt
@@ -1,5 +1,7 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
 enum class PullRequestStatus {
-    OPEN, MERGED, DECLINED
+    OPEN,
+    MERGED,
+    DECLINED,
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Ref.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Ref.kt
@@ -8,18 +8,18 @@ import java.util.Objects
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
     property = "type",
-    visible = true
+    visible = true,
 )
 @JsonSubTypes(
     JsonSubTypes.Type(Branch::class, name = "BRANCH"),
-    JsonSubTypes.Type(Tag::class, name = "TAG")
+    JsonSubTypes.Type(Tag::class, name = "TAG"),
 )
 abstract class Ref(
     val type: RefType,
     val name: String,
     val hash: String,
     val link: String,
-    val repository: Repository
+    val repository: Repository,
 ) : Comparable<Ref> {
     override fun compareTo(other: Ref) = compareBy(Ref::repository, Ref::type, Ref::name).compare(this, other)
 

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/RefType.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/RefType.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
 enum class RefType {
-    BRANCH, TAG
+    BRANCH,
+    TAG,
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Repository.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Repository.kt
@@ -1,7 +1,9 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
 data class Repository(
-    val sshUrl: String, val link: String, val avatar: String? = null
+    val sshUrl: String,
+    val link: String,
+    val avatar: String? = null,
 ) : Comparable<Repository> {
     override fun compareTo(other: Repository) = sshUrl compareTo other.sshUrl
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/RepositoryRange.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/RepositoryRange.kt
@@ -2,4 +2,9 @@ package org.octopusden.octopus.vcsfacade.client.common.dto
 
 import java.util.Date
 
-data class RepositoryRange(val sshUrl: String, val fromHashOrRef: String?, val fromDate: Date?, val toHashOrRef: String)
+data class RepositoryRange(
+    val sshUrl: String,
+    val fromHashOrRef: String?,
+    val fromDate: Date?,
+    val toHashOrRef: String,
+)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/RetryResponse.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/RetryResponse.kt
@@ -2,4 +2,7 @@ package org.octopusden.octopus.vcsfacade.client.common.dto
 
 import java.util.Date
 
-data class RetryResponse(val retryAfter: Date, val requestId: String)
+data class RetryResponse(
+    val retryAfter: Date,
+    val requestId: String,
+)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/SearchIssueInRangesResponse.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/SearchIssueInRangesResponse.kt
@@ -1,3 +1,5 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-data class SearchIssueInRangesResponse(val issueRanges: Map<String, Set<RepositoryRange>>)
+data class SearchIssueInRangesResponse(
+    val issueRanges: Map<String, Set<RepositoryRange>>,
+)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/SearchIssuesInRangesRequest.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/SearchIssuesInRangesRequest.kt
@@ -1,3 +1,6 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-data class SearchIssuesInRangesRequest(val issueKeys: Set<String>, val ranges: Set<RepositoryRange>)
+data class SearchIssuesInRangesRequest(
+    val issueKeys: Set<String>,
+    val ranges: Set<RepositoryRange>,
+)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/SearchSummary.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/SearchSummary.kt
@@ -5,9 +5,21 @@ import java.util.Date
 data class SearchSummary(
     val branches: SearchBranchesSummary,
     val commits: SearchCommitsSummary,
-    val pullRequests: SearchPullRequestsSummary
+    val pullRequests: SearchPullRequestsSummary,
 ) {
-    data class SearchBranchesSummary(val size: Int, val updated: Date?)
-    data class SearchCommitsSummary(val size: Int, val latest: Date?)
-    data class SearchPullRequestsSummary(val size: Int, val updated: Date?, val status: PullRequestStatus?)
+    data class SearchBranchesSummary(
+        val size: Int,
+        val updated: Date?,
+    )
+
+    data class SearchCommitsSummary(
+        val size: Int,
+        val latest: Date?,
+    )
+
+    data class SearchPullRequestsSummary(
+        val size: Int,
+        val updated: Date?,
+        val status: PullRequestStatus?,
+    )
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Tag.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/Tag.kt
@@ -1,6 +1,10 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-class Tag(name: String, hash: String, link: String, repository: Repository) :
-    Ref(RefType.TAG, name, hash, link, repository) {
+class Tag(
+    name: String,
+    hash: String,
+    link: String,
+    repository: Repository,
+) : Ref(RefType.TAG, name, hash, link, repository) {
     override fun toString() = "Tag(name=$name, hash=$hash, link=$link, repository=$repository)"
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/User.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/User.kt
@@ -1,3 +1,6 @@
 package org.octopusden.octopus.vcsfacade.client.common.dto
 
-data class User(val name: String, val avatar: String? = null)
+data class User(
+    val name: String,
+    val avatar: String? = null,
+)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/VcsFacadeErrorCode.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/dto/VcsFacadeErrorCode.kt
@@ -6,13 +6,12 @@ import org.octopusden.octopus.vcsfacade.client.common.exception.VcsFacadeExcepti
 
 enum class VcsFacadeErrorCode(
     private val getExceptionFunction: (message: String) -> VcsFacadeException,
-    val defaultMessage: String
+    val defaultMessage: String,
 ) {
     OTHER({ message -> VcsFacadeException(message) }, "Other"),
     NOT_FOUND({ message -> NotFoundException(message) }, "Not Found"),
-    ARGUMENTS_NOT_COMPATIBLE({ message -> ArgumentsNotCompatibleException(message) }, "Arguments not compatible");
+    ARGUMENTS_NOT_COMPATIBLE({ message -> ArgumentsNotCompatibleException(message) }, "Arguments not compatible"),
+    ;
 
-    fun getException(message: String): VcsFacadeException {
-        return getExceptionFunction.invoke(message)
-    }
+    fun getException(message: String): VcsFacadeException = getExceptionFunction.invoke(message)
 }

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/exception/ArgumentsNotCompatibleException.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/exception/ArgumentsNotCompatibleException.kt
@@ -1,3 +1,5 @@
 package org.octopusden.octopus.vcsfacade.client.common.exception
 
-class ArgumentsNotCompatibleException(message: String): VcsFacadeException(message)
+class ArgumentsNotCompatibleException(
+    message: String,
+) : VcsFacadeException(message)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/exception/NotFoundException.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/exception/NotFoundException.kt
@@ -1,3 +1,5 @@
 package org.octopusden.octopus.vcsfacade.client.common.exception
 
-class NotFoundException(message: String) : VcsFacadeException(message)
+class NotFoundException(
+    message: String,
+) : VcsFacadeException(message)

--- a/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/exception/VcsFacadeException.kt
+++ b/common/src/main/kotlin/org/octopusden/octopus/vcsfacade/client/common/exception/VcsFacadeException.kt
@@ -1,3 +1,5 @@
 package org.octopusden.octopus.vcsfacade.client.common.exception
 
-open class VcsFacadeException(message: String) : RuntimeException(message)
+open class VcsFacadeException(
+    message: String,
+) : RuntimeException(message)

--- a/ft/build.gradle.kts
+++ b/ft/build.gradle.kts
@@ -10,16 +10,17 @@ fun String.getExt() = project.ext[this] as String
 
 val commonOkdParameters = mapOf(
     "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
-    "DOCKER_REGISTRY" to "dockerRegistry".getExt()
+    "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
 )
 
-fun String.getPort() = when (this) {
-    "bitbucket" -> 7990
-    "gitea" -> 3000
-    "opensearch" -> 9200
-    "vcs-facade" -> 8080
-    else -> throw Exception("Unknown service '$this'")
-}
+fun String.getPort() =
+    when (this) {
+        "bitbucket" -> 7990
+        "gitea" -> 3000
+        "opensearch" -> 9200
+        "vcs-facade" -> 8080
+        else -> throw Exception("Unknown service '$this'")
+    }
 
 fun String.getDockerHost() = "localhost:${getPort()}"
 
@@ -35,7 +36,7 @@ ocTemplate {
     prefix.set("vcs-facade-ft")
     attempts.set(25)
 
-    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let{
+    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let {
         webConsoleUrl.set(it)
     }
 
@@ -55,25 +56,38 @@ ocTemplate {
         enabled.set("testProfile".getExt() == "bitbucket")
         service("bitbucket") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/bitbucket.yaml"))
-            parameters.set(commonOkdParameters + mapOf(
-                "BITBUCKET_LICENSE" to Base64.getEncoder().encodeToString("bitbucketLicense".getExt().toByteArray()),
-                "BITBUCKET_IMAGE_TAG" to properties["bitbucket.image-tag"] as String,
-                "POSTGRES_IMAGE_TAG" to properties["postgres.image-tag"] as String
-            ))
+            parameters.set(
+                commonOkdParameters + mapOf(
+                    "BITBUCKET_LICENSE" to Base64.getEncoder().encodeToString("bitbucketLicense".getExt().toByteArray()),
+                    "BITBUCKET_IMAGE_TAG" to properties["bitbucket.image-tag"] as String,
+                    "POSTGRES_IMAGE_TAG" to properties["postgres.image-tag"] as String,
+                ),
+            )
         }
     }
 
     service("vcs-facade") {
         templateFile.set(rootProject.layout.projectDirectory.file("okd/vcs-facade.yaml"))
-        parameters.set(commonOkdParameters + mapOf(
-            "VCS_FACADE_IMAGE_TAG" to version as String,
-            "VCS_FACADE_VCS_TYPE" to "testProfile".getExt(),
-            "VCS_FACADE_VCS_HOST" to getOkdExternalHost("testProfile".getExt()),
-            "VCS_FACADE_OPENSEARCH_HOST" to getOkdExternalHost("opensearch"),
-            "APPLICATION_DEV_CONTENT" to layout.projectDirectory.dir("docker/application-vcs-facade.yml").asFile.readText(),
-            "APPLICATION_GITEA_CONTENT" to layout.projectDirectory.dir("docker/gitea/application-gitea.yml").asFile.readText(),
-            "APPLICATION_BITBUCKET_CONTENT" to layout.projectDirectory.dir("docker/bitbucket/application-bitbucket.yml").asFile.readText()
-        ))
+        parameters.set(
+            commonOkdParameters + mapOf(
+                "VCS_FACADE_IMAGE_TAG" to version as String,
+                "VCS_FACADE_VCS_TYPE" to "testProfile".getExt(),
+                "VCS_FACADE_VCS_HOST" to getOkdExternalHost("testProfile".getExt()),
+                "VCS_FACADE_OPENSEARCH_HOST" to getOkdExternalHost("opensearch"),
+                "APPLICATION_DEV_CONTENT" to layout.projectDirectory
+                    .dir("docker/application-vcs-facade.yml")
+                    .asFile
+                    .readText(),
+                "APPLICATION_GITEA_CONTENT" to layout.projectDirectory
+                    .dir("docker/gitea/application-gitea.yml")
+                    .asFile
+                    .readText(),
+                "APPLICATION_BITBUCKET_CONTENT" to layout.projectDirectory
+                    .dir("docker/bitbucket/application-bitbucket.yml")
+                    .asFile
+                    .readText(),
+            ),
+        )
         if ("testProfile".getExt() == "gitea") {
             dependsOn.set(listOf("gitea", "opensearch"))
         } else {
@@ -85,9 +99,14 @@ ocTemplate {
 tasks["ocProcess"].dependsOn(":vcs-facade:dockerPushImage")
 
 configure<ComposeExtension> {
-    useComposeFiles.add("${projectDir}/docker/${"testProfile".getExt()}/docker-compose.yml")
+    useComposeFiles.add("$projectDir/docker/${"testProfile".getExt()}/docker-compose.yml")
     waitForTcpPorts.set(true)
-    captureContainersOutputToFiles.set(layout.buildDirectory.file("docker_logs").get().asFile)
+    captureContainersOutputToFiles.set(
+        layout.buildDirectory
+            .file("docker_logs")
+            .get()
+            .asFile,
+    )
     environment.putAll(
         mapOf(
             "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
@@ -97,12 +116,12 @@ configure<ComposeExtension> {
             "POSTGRES_IMAGE_TAG" to properties["postgres.image-tag"],
             "GITEA_IMAGE_TAG" to properties["gitea.image-tag"],
             "OPENSEARCH_IMAGE_TAG" to properties["opensearch.image-tag"],
-            "VCS_FACADE_IMAGE_TAG" to version as String
-        )
+            "VCS_FACADE_IMAGE_TAG" to version as String,
+        ),
     )
 }
 
-tasks["composeUp"].apply{
+tasks["composeUp"].apply {
     dependsOn(":vcs-facade:dockerBuildImage")
     doLast {
         if ("testProfile".getExt() == "gitea") {

--- a/ft/ktlint-baseline.xml
+++ b/ft/ktlint-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+</baseline>

--- a/ft/src/ft/kotlin/org/octopusden/octopus/vcsfacade/BaseVcsFacadeFunctionalTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/vcsfacade/BaseVcsFacadeFunctionalTest.kt
@@ -1,24 +1,27 @@
 package org.octopusden.octopus.vcsfacade
 
-import java.util.Date
 import org.octopusden.octopus.infrastructure.common.test.TestClient
 import org.octopusden.octopus.vcsfacade.client.common.dto.CreatePullRequest
 import org.octopusden.octopus.vcsfacade.client.common.dto.CreateTag
 import org.octopusden.octopus.vcsfacade.client.common.dto.SearchIssuesInRangesRequest
 import org.octopusden.octopus.vcsfacade.client.impl.ClassicVcsFacadeClient
 import org.octopusden.octopus.vcsfacade.client.impl.VcsFacadeClientParametersProvider
+import java.util.Date
 
 abstract class BaseVcsFacadeFunctionalTest(
-    testService: TestService, testClient: TestClient
+    testService: TestService,
+    testClient: TestClient,
 ) : BaseVcsFacadeTestExtended(testService, testClient) {
-    override fun createPullRequest(sshUrl: String, createPullRequest: CreatePullRequest) =
-        client.createPullRequest(sshUrl, createPullRequest)
+    override fun createPullRequest(
+        sshUrl: String,
+        createPullRequest: CreatePullRequest,
+    ) = client.createPullRequest(sshUrl, createPullRequest)
 
     override fun getCommits(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ) = client.getCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
 
     override fun getCommitsWithFiles(
@@ -26,31 +29,48 @@ abstract class BaseVcsFacadeFunctionalTest(
         fromHashOrRef: String?,
         fromDate: Date?,
         toHashOrRef: String,
-        commitFilesLimit: Int?
+        commitFilesLimit: Int?,
     ) = client.getCommitsWithFiles(sshUrl, fromHashOrRef, fromDate, toHashOrRef, commitFilesLimit)
 
-    override fun getCommit(sshUrl: String, hashOrRef: String) = client.getCommit(sshUrl, hashOrRef)
+    override fun getCommit(
+        sshUrl: String,
+        hashOrRef: String,
+    ) = client.getCommit(sshUrl, hashOrRef)
 
-    override fun getCommitWithFiles(sshUrl: String, hashOrRef: String, commitFilesLimit: Int?) =
-        client.getCommitWithFiles(sshUrl, hashOrRef, commitFilesLimit)
+    override fun getCommitWithFiles(
+        sshUrl: String,
+        hashOrRef: String,
+        commitFilesLimit: Int?,
+    ) = client.getCommitWithFiles(sshUrl, hashOrRef, commitFilesLimit)
 
     override fun getIssuesFromCommits(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ) = client.getIssuesFromCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
 
-    override fun getTags(sshUrl: String, names: Set<String>?) = client.getTags(sshUrl, names)
+    override fun getTags(
+        sshUrl: String,
+        names: Set<String>?,
+    ) = client.getTags(sshUrl, names)
 
-    override fun createTag(sshUrl: String, createTag: CreateTag) = client.createTag(sshUrl, createTag)
+    override fun createTag(
+        sshUrl: String,
+        createTag: CreateTag,
+    ) = client.createTag(sshUrl, createTag)
 
-    override fun getTag(sshUrl: String, name: String) = client.getTag(sshUrl, name)
+    override fun getTag(
+        sshUrl: String,
+        name: String,
+    ) = client.getTag(sshUrl, name)
 
-    override fun deleteTag(sshUrl: String, name: String) = client.deleteTag(sshUrl, name)
+    override fun deleteTag(
+        sshUrl: String,
+        name: String,
+    ) = client.deleteTag(sshUrl, name)
 
-    override fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest) =
-        client.searchIssuesInRanges(searchRequest)
+    override fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest) = client.searchIssuesInRanges(searchRequest)
 
     override fun findByIssueKeys(issueKeys: Set<String>) = client.findByIssueKeys(issueKeys)
 
@@ -58,8 +78,10 @@ abstract class BaseVcsFacadeFunctionalTest(
 
     override fun findCommitsByIssueKeys(issueKeys: Set<String>) = client.findCommitsByIssueKeys(issueKeys)
 
-    override fun findCommitsWithFilesByIssueKeys(issueKeys: Set<String>, commitFilesLimit: Int?) =
-        client.findCommitsWithFilesByIssueKeys(issueKeys, commitFilesLimit)
+    override fun findCommitsWithFilesByIssueKeys(
+        issueKeys: Set<String>,
+        commitFilesLimit: Int?,
+    ) = client.findCommitsWithFilesByIssueKeys(issueKeys, commitFilesLimit)
 
     override fun findPullRequestsByIssueKeys(issueKeys: Set<String>) = client.findPullRequestsByIssueKeys(issueKeys)
 
@@ -70,6 +92,7 @@ abstract class BaseVcsFacadeFunctionalTest(
         @JvmStatic
         protected val client = ClassicVcsFacadeClient(object : VcsFacadeClientParametersProvider {
             override fun getApiUrl() = "http://$vcsFacadeHost"
+
             override fun getTimeRetryInMillis() = 180000
         })
 

--- a/ft/src/ft/kotlin/org/octopusden/octopus/vcsfacade/VcsFacadeFunctionalTestBitbucket.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/vcsfacade/VcsFacadeFunctionalTestBitbucket.kt
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.octopusden.octopus.infastructure.bitbucket.test.BitbucketTestClient
 
 @EnabledIfSystemProperty(named = "test.profile", matches = "bitbucket")
-class VcsFacadeFunctionalTestBitbucket : BaseVcsFacadeFunctionalTest(
-    TestService.Bitbucket(vcsFacadeHost, vcsExternalHost),
-    BitbucketTestClient("http://$vcsHost", BITBUCKET_USER, BITBUCKET_PASSWORD, vcsExternalHost)
-)
+class VcsFacadeFunctionalTestBitbucket :
+    BaseVcsFacadeFunctionalTest(
+        TestService.Bitbucket(vcsFacadeHost, vcsExternalHost),
+        BitbucketTestClient("http://$vcsHost", BITBUCKET_USER, BITBUCKET_PASSWORD, vcsExternalHost),
+    )

--- a/ft/src/ft/kotlin/org/octopusden/octopus/vcsfacade/VcsFacadeFunctionalTestGitea.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/vcsfacade/VcsFacadeFunctionalTestGitea.kt
@@ -1,12 +1,5 @@
 package org.octopusden.octopus.vcsfacade
 
-import java.io.File
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse.BodyHandlers
-import java.util.Base64
-import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -15,13 +8,20 @@ import org.octopusden.octopus.infrastructure.common.test.dto.NewChangeSet
 import org.octopusden.octopus.infrastructure.gitea.test.GiteaTestClient
 import org.octopusden.octopus.vcsfacade.client.common.dto.CreatePullRequest
 import org.octopusden.octopus.vcsfacade.client.common.dto.PullRequestStatus
-
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+import java.util.Base64
+import java.util.concurrent.TimeUnit
 
 @EnabledIfSystemProperty(named = "test.profile", matches = "gitea")
-class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
-    TestService.Gitea(vcsFacadeHost, vcsExternalHost, true),
-    GiteaTestClient("http://$vcsHost", GITEA_USER, GITEA_PASSWORD, vcsExternalHost)
-) {
+class VcsFacadeFunctionalTestGitea :
+    BaseVcsFacadeFunctionalTest(
+        TestService.Gitea(vcsFacadeHost, vcsExternalHost, true),
+        GiteaTestClient("http://$vcsHost", GITEA_USER, GITEA_PASSWORD, vcsExternalHost),
+    ) {
     @BeforeAll
     fun beforeAllVcsFacadeFunctionalTestGitea() {
         (testService as TestService.Gitea).scan(GROUP, REPOSITORY_2)
@@ -38,10 +38,11 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
             testService.sshUrl(GROUP, repository),
             File.createTempFile("VcsFacadeFunctionalTestGitea-", "-$GROUP-$repository").apply {
                 outputStream().use {
-                    BaseVcsFacadeTest::class.java.classLoader.getResourceAsStream("$GROUP-$REPOSITORY_2.zip")!!
+                    BaseVcsFacadeTest::class.java.classLoader
+                        .getResourceAsStream("$GROUP-$REPOSITORY_2.zip")!!
                         .copyTo(it)
                 }
-            }
+            },
         )
         doHttpRequest(webhookCreationRequest(GROUP, repository))
         doHttpRequest(makeUserCollaboratorRequest(GROUP, repository, ASSIGNEE))
@@ -49,7 +50,7 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
         doHttpRequest(makeUserCollaboratorRequest(GROUP, repository, APPROVER))
         testClient.commit(
             NewChangeSet("Commit ($issue)", testService.sshUrl(GROUP, repository), issue),
-            "master"
+            "master",
         )
         check("Commit and branch for $issue have not been registered") {
             with(findByIssueKeys(setOf(issue))) {
@@ -58,7 +59,7 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
         }
         createPullRequest(
             testService.sshUrl(GROUP, repository),
-            CreatePullRequest(issue, "master", "Webhook test PR", "Description $issue")
+            CreatePullRequest(issue, "master", "Webhook test PR", "Description $issue"),
         )
         check("Pull request for $issue has not been registered") {
             with(findByIssueKeys(setOf(issue))) {
@@ -74,31 +75,46 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
         doHttpRequest(setPullRequestAssigneeRequest(GROUP, repository, pullRequestIndex, ASSIGNEE))
         check("Assigning of pull request $pullRequestIndex has not been registered") {
             with(findPullRequestsByIssueKeys(setOf(issue))) {
-                size == 1 && this[0].index == pullRequestIndex && this[0].status == PullRequestStatus.OPEN &&
-                        this[0].assignees.size == 1 && this[0].assignees[0].name == ASSIGNEE
+                size == 1 &&
+                    this[0].index == pullRequestIndex &&
+                    this[0].status == PullRequestStatus.OPEN &&
+                    this[0].assignees.size == 1 &&
+                    this[0].assignees[0].name == ASSIGNEE
             }
         }
         doHttpRequest(addPullRequestReviewerRequest(GROUP, repository, pullRequestIndex, REVIEWER))
         doHttpRequest(addPullRequestReviewerRequest(GROUP, repository, pullRequestIndex, APPROVER))
         check("Addition of review requests for pull request $pullRequestIndex has not been registered") {
             with(findPullRequestsByIssueKeys(setOf(issue))) {
-                size == 1 && this[0].index == pullRequestIndex && this[0].status == PullRequestStatus.OPEN &&
-                        this[0].reviewers.size == 2 && this[0].reviewers.none { it.approved } &&
-                        this[0].reviewers.any { it.user.name == REVIEWER } && this[0].reviewers.any { it.user.name == APPROVER }
+                size == 1 &&
+                    this[0].index == pullRequestIndex &&
+                    this[0].status == PullRequestStatus.OPEN &&
+                    this[0].reviewers.size == 2 &&
+                    this[0].reviewers.none { it.approved } &&
+                    this[0].reviewers.any { it.user.name == REVIEWER } &&
+                    this[0].reviewers.any { it.user.name == APPROVER }
             }
         }
         doHttpRequest(deletePullRequestReviewerRequest(GROUP, repository, pullRequestIndex, REVIEWER))
         check("Deletion of review request for pull request $pullRequestIndex has not been registered") {
             with(findPullRequestsByIssueKeys(setOf(issue))) {
-                size == 1 && this[0].index == pullRequestIndex && this[0].status == PullRequestStatus.OPEN &&
-                        this[0].reviewers.size == 1 && this[0].reviewers[0].user.name == APPROVER && !this[0].reviewers[0].approved
+                size == 1 &&
+                    this[0].index == pullRequestIndex &&
+                    this[0].status == PullRequestStatus.OPEN &&
+                    this[0].reviewers.size == 1 &&
+                    this[0].reviewers[0].user.name == APPROVER &&
+                    !this[0].reviewers[0].approved
             }
         }
         doHttpRequest(approvePullRequestRequest(GROUP, repository, pullRequestIndex, APPROVER))
         check("Approval of pull request $pullRequestIndex has not been registered") {
             with(findPullRequestsByIssueKeys(setOf(issue))) {
-                size == 1 && this[0].index == pullRequestIndex && this[0].status == PullRequestStatus.OPEN &&
-                        this[0].reviewers.size == 1 && this[0].reviewers[0].user.name == APPROVER && this[0].reviewers[0].approved
+                size == 1 &&
+                    this[0].index == pullRequestIndex &&
+                    this[0].status == PullRequestStatus.OPEN &&
+                    this[0].reviewers.size == 1 &&
+                    this[0].reviewers[0].user.name == APPROVER &&
+                    this[0].reviewers[0].approved
             }
         }
         doHttpRequest(mergePullRequestRequest(GROUP, repository, pullRequestIndex))
@@ -140,7 +156,10 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
         private const val REVIEWER = "test-reviewer"
         private const val APPROVER = "test-approver"
 
-        private fun check(failMessage: String, checkFunction: () -> Boolean) {
+        private fun check(
+            failMessage: String,
+            checkFunction: () -> Boolean,
+        ) {
             var success = false
             for (i in 1..5) {
                 Thread.sleep(1000L * i)
@@ -150,8 +169,8 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
             if (!success) throw RuntimeException(failMessage)
         }
 
-        //TODO: implement some of below functionality in Gitea client?
-        //<editor-fold defaultstate="collapsed" desc="http requests data">
+        // TODO: implement some of below functionality in Gitea client?
+        // <editor-fold defaultstate="collapsed" desc="http requests data">
 
         private val httpClient = HttpClient.newHttpClient()
 
@@ -161,25 +180,26 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
             val user: String,
             val password: String,
             val body: String,
-            val failMessage: String
+            val failMessage: String,
         )
 
         private fun doHttpRequest(giteaHttpRequest: GiteaHttpRequest) {
             with(
                 httpClient.send(
-                    HttpRequest.newBuilder()
+                    HttpRequest
+                        .newBuilder()
                         .uri(URI("http://$vcsHost/api/v1/${giteaHttpRequest.path}"))
                         .header(
                             "Authorization",
-                            "Basic " + Base64.getEncoder()
-                                .encodeToString("${giteaHttpRequest.user}:${giteaHttpRequest.password}".toByteArray())
-                        )
-                        .header("Content-Type", "application/json")
+                            "Basic " + Base64
+                                .getEncoder()
+                                .encodeToString("${giteaHttpRequest.user}:${giteaHttpRequest.password}".toByteArray()),
+                        ).header("Content-Type", "application/json")
                         .header("Accept", "application/json")
                         .method(giteaHttpRequest.method, HttpRequest.BodyPublishers.ofString(giteaHttpRequest.body))
                         .build(),
-                    BodyHandlers.ofString()
-                )
+                    BodyHandlers.ofString(),
+                ),
             ) {
                 if (statusCode() / 100 != 2) {
                     throw RuntimeException("${giteaHttpRequest.failMessage}\n${body()}")
@@ -187,16 +207,20 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
             }
         }
 
-        private fun userCreationRequest(user: String) = GiteaHttpRequest(
-            "admin/users",
-            "POST",
-            GITEA_USER,
-            GITEA_PASSWORD,
-            """{"email": "$user@domain.corp", "username": "$user", "password": "$user", "must_change_password": false}""",
-            "Unable to create '$user' user"
-        )
+        private fun userCreationRequest(user: String) =
+            GiteaHttpRequest(
+                "admin/users",
+                "POST",
+                GITEA_USER,
+                GITEA_PASSWORD,
+                """{"email": "$user@domain.corp", "username": "$user", "password": "$user", "must_change_password": false}""",
+                "Unable to create '$user' user",
+            )
 
-        private fun webhookCreationRequest(organization: String, repository: String) = GiteaHttpRequest(
+        private fun webhookCreationRequest(
+            organization: String,
+            repository: String,
+        ) = GiteaHttpRequest(
             "repos/$organization/$repository/hooks",
             "POST",
             GITEA_USER,
@@ -220,71 +244,90 @@ class VcsFacadeFunctionalTestGitea : BaseVcsFacadeFunctionalTest(
     "authorization_header": "",
     "active": true
 }""",
-            "Unable to create webhook for '$organization:$repository' repository"
+            "Unable to create webhook for '$organization:$repository' repository",
         )
 
-        private fun makeUserCollaboratorRequest(organization: String, repository: String, user: String) =
-            GiteaHttpRequest(
-                "repos/$organization/$repository/collaborators/$user",
-                "PUT",
-                GITEA_USER,
-                GITEA_PASSWORD,
-                """{"permission": "write"}""",
-                "Unable to make user '$user' collaborator of '$organization:$repository' repository"
-            )
+        private fun makeUserCollaboratorRequest(
+            organization: String,
+            repository: String,
+            user: String,
+        ) = GiteaHttpRequest(
+            "repos/$organization/$repository/collaborators/$user",
+            "PUT",
+            GITEA_USER,
+            GITEA_PASSWORD,
+            """{"permission": "write"}""",
+            "Unable to make user '$user' collaborator of '$organization:$repository' repository",
+        )
 
-        private fun setPullRequestAssigneeRequest(organization: String, repository: String, index: Long, user: String) =
-            GiteaHttpRequest(
-                "repos/$organization/$repository/pulls/$index",
-                "PATCH",
-                GITEA_USER,
-                GITEA_PASSWORD,
-                """{"assignee": "$user"}""",
-                "Unable to make user '$user' assignee in pull request $index in '$organization:$repository' repository"
-            )
+        private fun setPullRequestAssigneeRequest(
+            organization: String,
+            repository: String,
+            index: Long,
+            user: String,
+        ) = GiteaHttpRequest(
+            "repos/$organization/$repository/pulls/$index",
+            "PATCH",
+            GITEA_USER,
+            GITEA_PASSWORD,
+            """{"assignee": "$user"}""",
+            "Unable to make user '$user' assignee in pull request $index in '$organization:$repository' repository",
+        )
 
-        private fun addPullRequestReviewerRequest(organization: String, repository: String, index: Long, user: String) =
-            GiteaHttpRequest(
-                "repos/$organization/$repository/pulls/$index/requested_reviewers",
-                "POST",
-                GITEA_USER,
-                GITEA_PASSWORD,
-                """{"reviewers": ["$user"]}""",
-                "Unable to add review request for '$user' reviewer in pull request $index in '$organization:$repository' repository"
-            )
+        private fun addPullRequestReviewerRequest(
+            organization: String,
+            repository: String,
+            index: Long,
+            user: String,
+        ) = GiteaHttpRequest(
+            "repos/$organization/$repository/pulls/$index/requested_reviewers",
+            "POST",
+            GITEA_USER,
+            GITEA_PASSWORD,
+            """{"reviewers": ["$user"]}""",
+            "Unable to add review request for '$user' reviewer in pull request $index in '$organization:$repository' repository",
+        )
 
         private fun deletePullRequestReviewerRequest(
             organization: String,
             repository: String,
             index: Long,
-            user: String
+            user: String,
         ) = GiteaHttpRequest(
             "repos/$organization/$repository/pulls/$index/requested_reviewers",
             "DELETE",
             GITEA_USER,
             GITEA_PASSWORD,
             """{"reviewers": ["$user"]}""",
-            "Unable to delete review request for '$user' reviewer in pull request $index in '$organization:$repository' repository"
+            "Unable to delete review request for '$user' reviewer in pull request $index in '$organization:$repository' repository",
         )
 
-        private fun approvePullRequestRequest(organization: String, repository: String, index: Long, user: String) =
-            GiteaHttpRequest(
-                "repos/$organization/$repository/pulls/$index/reviews",
-                "POST",
-                user,
-                user,
-                """{"event": "APPROVED"}""",
-                "Unable to approve pull request $index in '$organization:$repository' repository by '$user' user"
-            )
+        private fun approvePullRequestRequest(
+            organization: String,
+            repository: String,
+            index: Long,
+            user: String,
+        ) = GiteaHttpRequest(
+            "repos/$organization/$repository/pulls/$index/reviews",
+            "POST",
+            user,
+            user,
+            """{"event": "APPROVED"}""",
+            "Unable to approve pull request $index in '$organization:$repository' repository by '$user' user",
+        )
 
-        private fun mergePullRequestRequest(organization: String, repository: String, index: Long) = GiteaHttpRequest(
+        private fun mergePullRequestRequest(
+            organization: String,
+            repository: String,
+            index: Long,
+        ) = GiteaHttpRequest(
             "repos/$organization/$repository/pulls/$index/merge",
             "POST",
             GITEA_USER,
             GITEA_PASSWORD,
             """{"Do": "merge"}""",
-            "Unable to merge pull request $index in '$organization:$repository' repository"
+            "Unable to merge pull request $index in '$organization:$repository' repository",
         )
-        //</editor-fold>
+        // </editor-fold>
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ octopus-oc-template.version=2.0.7
 
 # Octopus quality-gates convention plugin + Kotlin static-analysis tools.
 # Versions live here (single source of truth), consumed by settings.gradle.kts pluginManagement.
-octopus-quality.version=2.4.0
+octopus-quality.version=2.4.1
 detekt.version=1.23.8
 ktlint.version=14.0.1
 #

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ octopus-oc-template.version=2.0.7
 
 # Octopus quality-gates convention plugin + Kotlin static-analysis tools.
 # Versions live here (single source of truth), consumed by settings.gradle.kts pluginManagement.
-octopus-quality.version=2.3.5
+octopus-quality.version=2.4.0
 detekt.version=1.23.8
 ktlint.version=14.0.1
 #

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,12 @@ spring-data-opensearch.version=1.3.0
 springdoc-openapi.version=2.3.0
 external-systems-client.version=2.0.63
 octopus-oc-template.version=2.0.7
+
+# Octopus quality-gates convention plugin + Kotlin static-analysis tools.
+# Versions live here (single source of truth), consumed by settings.gradle.kts pluginManagement.
+octopus-quality.version=2.3.5
+detekt.version=1.23.8
+ktlint.version=14.0.1
 #
 bitbucket.image-tag=9.4.13
 postgres.image-tag=17-alpine

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -52,15 +52,16 @@ fun String.getExt() = project.ext[this] as String
 
 val commonOkdParameters = mapOf(
     "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
-    "DOCKER_REGISTRY" to "dockerRegistry".getExt()
+    "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
 )
 
-fun String.getPort() = when (this) {
-    "bitbucket" -> 7990
-    "gitea" -> 3000
-    "opensearch" -> 9200
-    else -> throw Exception("Unknown service '$this'")
-}
+fun String.getPort() =
+    when (this) {
+        "bitbucket" -> 7990
+        "gitea" -> 3000
+        "opensearch" -> 9200
+        else -> throw Exception("Unknown service '$this'")
+    }
 
 fun String.getDockerHost() = "localhost:${getPort()}"
 
@@ -71,7 +72,7 @@ ocTemplate {
     namespace.set("okdProject".getExt())
     prefix.set("vcs-facade-ut")
 
-    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let{
+    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let {
         webConsoleUrl.set(it)
     }
 
@@ -91,19 +92,26 @@ ocTemplate {
         enabled.set("testProfile".getExt() == "bitbucket")
         service("bitbucket") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/bitbucket.yaml"))
-            parameters.set(commonOkdParameters + mapOf(
-                "BITBUCKET_LICENSE" to Base64.getEncoder().encodeToString("bitbucketLicense".getExt().toByteArray()),
-                "BITBUCKET_IMAGE_TAG" to properties["bitbucket.image-tag"] as String,
-                "POSTGRES_IMAGE_TAG" to properties["postgres.image-tag"] as String
-            ))
+            parameters.set(
+                commonOkdParameters + mapOf(
+                    "BITBUCKET_LICENSE" to Base64.getEncoder().encodeToString("bitbucketLicense".getExt().toByteArray()),
+                    "BITBUCKET_IMAGE_TAG" to properties["bitbucket.image-tag"] as String,
+                    "POSTGRES_IMAGE_TAG" to properties["postgres.image-tag"] as String,
+                ),
+            )
         }
     }
 }
 
 configure<ComposeExtension> {
-    useComposeFiles.add("${projectDir}/docker/${"testProfile".getExt()}/docker-compose.yml")
+    useComposeFiles.add("$projectDir/docker/${"testProfile".getExt()}/docker-compose.yml")
     waitForTcpPorts.set(true)
-    captureContainersOutputToFiles.set(layout.buildDirectory.file("docker_logs").get().asFile)
+    captureContainersOutputToFiles.set(
+        layout.buildDirectory
+            .file("docker_logs")
+            .get()
+            .asFile,
+    )
     environment.putAll(
         mapOf(
             "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
@@ -112,7 +120,7 @@ configure<ComposeExtension> {
             "POSTGRES_IMAGE_TAG" to properties["postgres.image-tag"],
             "GITEA_IMAGE_TAG" to properties["gitea.image-tag"],
             "OPENSEARCH_IMAGE_TAG" to properties["opensearch.image-tag"],
-        )
+        ),
     )
 }
 
@@ -166,7 +174,9 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-config")
     implementation("org.opensearch.client:spring-data-opensearch:${properties["spring-data-opensearch.version"]}")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${properties["springdoc-openapi.version"]}")
-    implementation("org.octopusden.octopus.octopus-external-systems-clients:bitbucket-client:${properties["external-systems-client.version"]}")
+    implementation(
+        "org.octopusden.octopus.octopus-external-systems-clients:bitbucket-client:${properties["external-systems-client.version"]}",
+    )
     implementation("org.octopusden.octopus.octopus-external-systems-clients:gitea-client:${properties["external-systems-client.version"]}")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/server/detekt-baseline.xml
+++ b/server/detekt-baseline.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ClassOrdering:IndexerServiceImpl.kt$IndexerServiceImpl$private val repositoryScanQueue = mutableMapOf&lt;RepositoryInfoDocument, Future&lt;*&gt;&gt;()</ID>
+    <ID>ClassOrdering:IssueKeyParser.kt$IssueKeyParser$private val issueKeyFindRegex = "(?:^|[^_A-Z0-9])($ISSUE_KEY_PATTERN)".toRegex()</ID>
+    <ID>ClassOrdering:VcsServiceSshUrlParsingTest.kt$VcsServiceSshUrlParsingTest$private fun createService( sshUrl: String, type: VcsServiceType, ): VcsService</ID>
+    <ID>ComplexCondition:IndexerController.kt$IndexerController$( event == "pull_request" &amp;&amp; (eventType == "pull_request" || eventType == "pull_request_assign" || eventType == "pull_request_review_request") ) || (event == "pull_request_approved" &amp;&amp; eventType == "pull_request_review_approved") || (event == "pull_request_rejected" &amp;&amp; eventType == "pull_request_review_rejected")</ID>
+    <ID>CyclomaticComplexMethod:IndexerController.kt$IndexerController$@PostMapping("gitea/webhook") fun processGiteaWebhookEvent( @RequestParam("vcsServiceId") vcsServiceId: String, @RequestHeader("x-gitea-event") event: String, @RequestHeader("x-gitea-event-type") eventType: String, @RequestHeader("x-gitea-signature") signature: String?, request: HttpServletRequest, )</ID>
+    <ID>ForbiddenComment:CommitDocument.kt$CommitDocument$// TODO: Sometimes a commit contains enormous number of affected files. Is it better to store files in separate index?</ID>
+    <ID>ForbiddenComment:GiteaService.kt$GiteaService$// TODO: add "useColon" parameter?</ID>
+    <ID>ForbiddenComment:IndexerController.kt$IndexerController$// TODO: support BitBucket webhooks</ID>
+    <ID>ForbiddenComment:RepositoryController.kt$RepositoryController$// TODO: use some concurrent map with timed entry eviction</ID>
+    <ID>ForbiddenComment:VcsManager.kt$VcsManager$// TODO: allow to use both http and ssh repository url (renaming `sshUrl` to `repositoryUrl`)</ID>
+    <ID>ImplicitDefaultLocale:IndexerController.kt$IndexerController$String.format("%02X", b)</ID>
+    <ID>MaxLineLength:CommitDocument.kt$CommitDocument$"CommitDocument(id=$id, repository=$repository, hash=$hash, message=$message, date=$date, author=$author, parents=$parents, link=$link)"</ID>
+    <ID>MaxLineLength:OpenSearchServiceImpl.kt$OpenSearchServiceImpl.Companion$/* IMPORTANT: use raw `search_after` approach because: * - native query builder required to use `search_after` with PIT or to `scroll` (spring-data-opensearch does not fully support Spring Data JPA Scroll API) * - limitation of raw `search_after` (inconsistency because of concurrent operations) is suitable, consistency is complied by vcs services * - better performance of raw `search_after` comparing with `search_after` with PIT or `scroll` */</ID>
+    <ID>MaxLineLength:PullRequestDocument.kt$PullRequestDocument$"PullRequestDocument(id=$id, repository=$repository, index=$index, title=$title, description=$description, author=$author, source=$source, target=$target, assignees=$assignees, reviewers=$reviewers, status=$status, createdAt=$createdAt, updatedAt=$updatedAt, link=$link)"</ID>
+    <ID>SwallowedException:BaseVcsFacadeUnitTest.kt$BaseVcsFacadeUnitTest$e: Exception</ID>
+    <ID>SwallowedException:BitbucketService.kt$BitbucketService$e: NotFoundException</ID>
+    <ID>SwallowedException:GiteaService.kt$GiteaService$e: NotFoundException</ID>
+    <ID>SwallowedException:RepositoryController.kt$RepositoryController$e: ExecutionException</ID>
+    <ID>TooGenericExceptionCaught:IndexerServiceImpl.kt$IndexerServiceImpl$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:VcsManagerImpl.kt$VcsManagerImpl$e: Exception</ID>
+    <ID>TooGenericExceptionThrown:BaseVcsFacadeUnitTest.kt$BaseVcsFacadeUnitTest.Companion$throw Exception("System property 'test.vcs-facade-host' must be defined")</ID>
+    <ID>TooGenericExceptionThrown:BaseVcsFacadeUnitTest.kt$BaseVcsFacadeUnitTest.Companion$throw Exception("System property 'test.vcs-host' must be defined")</ID>
+    <ID>TooManyFunctions:BitbucketService.kt$BitbucketService : VcsService</ID>
+    <ID>TooManyFunctions:GiteaService.kt$GiteaService : VcsService</ID>
+    <ID>TooManyFunctions:IndexerServiceImpl.kt$IndexerServiceImpl : IndexerService</ID>
+    <ID>TooManyFunctions:OpenSearchService.kt$OpenSearchService</ID>
+    <ID>TooManyFunctions:OpenSearchService.kt$OpenSearchService$Companion</ID>
+    <ID>TooManyFunctions:OpenSearchServiceImpl.kt$OpenSearchServiceImpl : OpenSearchService</ID>
+    <ID>TooManyFunctions:RepositoryController.kt$RepositoryController</ID>
+    <ID>TooManyFunctions:VcsManager.kt$VcsManager</ID>
+    <ID>TooManyFunctions:VcsManagerImpl.kt$VcsManagerImpl : VcsManagerHealthIndicator</ID>
+    <ID>TooManyFunctions:VcsService.kt$VcsService</ID>
+    <ID>UnusedPrivateMember:IndexerServiceImpl.kt$IndexerServiceImpl$@Scheduled(cron = "#{ @opensearchIndexScheduleRepositoriesRescanCron }") private fun scheduleRepositoriesRescan()</ID>
+    <ID>UnusedPrivateMember:IndexerServiceImpl.kt$IndexerServiceImpl$@Scheduled(fixedDelayString = "#{ @opensearchIndexSubmitScheduledRepositoriesScanFixedDelay }") private fun submitScheduledRepositoriesScan()</ID>
+    <ID>UseCheckOrError:IndexerServiceImpl.kt$IndexerServiceImpl$throw IllegalStateException("There is no configured Gitea service with id '$id' and enabled indexing")</ID>
+    <ID>UseCheckOrError:VcsManagerImpl.kt$VcsManagerImpl$throw IllegalStateException("${it.value.size} VCS services have similar id '${it.key}'")</ID>
+    <ID>UseCheckOrError:VcsManagerImpl.kt$VcsManagerImpl$throw IllegalStateException("There is no configured VCS service for '$sshUrl'")</ID>
+    <ID>UseCheckOrError:VcsManagerImpl.kt$VcsManagerImpl$throw IllegalStateException("There is no configured VCS service with id '$id'")</ID>
+    <ID>UseCheckOrError:VcsProperties.kt$VcsProperties.Service$throw IllegalStateException("Auth token or username/password must be specified")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/server/ktlint-baseline.xml
+++ b/server/ktlint-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+</baseline>

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/ExecutorProperties.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/ExecutorProperties.kt
@@ -8,14 +8,15 @@ data class ExecutorProperties(
     val queueCapacity: Int? = null,
     val keepAliveSeconds: Int? = null,
     val allowCoreThreadTimeout: Boolean? = null,
-    val preStartAllCoreThreads: Boolean? = null
+    val preStartAllCoreThreads: Boolean? = null,
 ) {
-    fun buildThreadPoolTaskExecutor() = ThreadPoolTaskExecutor().apply {
-        this@ExecutorProperties.corePoolSize?.let { corePoolSize = it }
-        this@ExecutorProperties.maxPoolSize?.let { maxPoolSize = it }
-        this@ExecutorProperties.queueCapacity?.let { queueCapacity = it }
-        this@ExecutorProperties.keepAliveSeconds?.let { keepAliveSeconds = it }
-        this@ExecutorProperties.allowCoreThreadTimeout?.let { setAllowCoreThreadTimeOut(it) }
-        this@ExecutorProperties.preStartAllCoreThreads?.let { setPrestartAllCoreThreads(it) }
-    }
+    fun buildThreadPoolTaskExecutor() =
+        ThreadPoolTaskExecutor().apply {
+            this@ExecutorProperties.corePoolSize?.let { corePoolSize = it }
+            this@ExecutorProperties.maxPoolSize?.let { maxPoolSize = it }
+            this@ExecutorProperties.queueCapacity?.let { queueCapacity = it }
+            this@ExecutorProperties.keepAliveSeconds?.let { keepAliveSeconds = it }
+            this@ExecutorProperties.allowCoreThreadTimeout?.let { setAllowCoreThreadTimeOut(it) }
+            this@ExecutorProperties.preStartAllCoreThreads?.let { setPrestartAllCoreThreads(it) }
+        }
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/JobConfig.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/JobConfig.kt
@@ -5,12 +5,14 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class JobConfig(private val jobProperties: JobProperties) {
+class JobConfig(
+    private val jobProperties: JobProperties,
+) {
     @ConfigurationProperties("vcs-facade.job")
     data class JobProperties(
         val fastWorkTimoutSecs: Int,
         val retryIntervalSecs: Int,
-        val executor: ExecutorProperties?
+        val executor: ExecutorProperties?,
     )
 
     @Bean

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/OpenSearchConfig.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/OpenSearchConfig.kt
@@ -9,12 +9,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-
 @Configuration
-class OpenSearchConfig(private val openSearchProperties: OpenSearchProperties?) {
+class OpenSearchConfig(
+    private val openSearchProperties: OpenSearchProperties?,
+) {
     @ConfigurationProperties("vcs-facade.opensearch")
     @ConditionalOnProperty(
-        prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+        prefix = "vcs-facade.opensearch",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = true,
     )
     data class OpenSearchProperties(
         val host: String,
@@ -23,27 +27,30 @@ class OpenSearchConfig(private val openSearchProperties: OpenSearchProperties?) 
         val socketTimeout: Long?,
         val username: String,
         val password: String,
-        val index: Index
+        val index: Index,
     ) {
         data class Index(
             val suffix: String,
             val webhookSecret: String?,
-            val scan: Scan?
+            val scan: Scan?,
         ) {
             data class Scan(
                 val cron: String?,
                 val delay: Long?,
-                val executor: ExecutorProperties?
+                val executor: ExecutorProperties?,
             )
         }
     }
 
     @Configuration
     @ConditionalOnProperty(
-        prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+        prefix = "vcs-facade.opensearch",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = true,
     )
     class OpenSearchEnabledConfig(
-        private val openSearchProperties: OpenSearchProperties
+        private val openSearchProperties: OpenSearchProperties,
     ) : AbstractOpenSearchConfiguration() {
         override fun opensearchClient(): RestHighLevelClient {
             val clientConfigurationBuilder = if (openSearchProperties.ssl) {
@@ -57,11 +64,14 @@ class OpenSearchConfig(private val openSearchProperties: OpenSearchProperties?) 
             openSearchProperties.socketTimeout?.let {
                 clientConfigurationBuilder.withSocketTimeout(it)
             }
-            return RestClients.create(
-                clientConfigurationBuilder.withBasicAuth(
-                    openSearchProperties.username, openSearchProperties.password
-                ).build()
-            ).rest()
+            return RestClients
+                .create(
+                    clientConfigurationBuilder
+                        .withBasicAuth(
+                            openSearchProperties.username,
+                            openSearchProperties.password,
+                        ).build(),
+                ).rest()
         }
 
         @Bean
@@ -69,12 +79,12 @@ class OpenSearchConfig(private val openSearchProperties: OpenSearchProperties?) 
             (openSearchProperties.index.scan?.executor ?: ExecutorProperties()).buildThreadPoolTaskExecutor()
     }
 
-    @Bean //dedicated bean to simplify SpEL expression
+    @Bean // dedicated bean to simplify SpEL expression
     fun opensearchIndexSuffix() = openSearchProperties?.index?.suffix ?: "undefined"
 
-    @Bean //dedicated bean to simplify SpEL expression
+    @Bean // dedicated bean to simplify SpEL expression
     fun opensearchIndexScheduleRepositoriesRescanCron() = openSearchProperties?.index?.scan?.cron ?: "-"
 
-    @Bean //dedicated bean to simplify SpEL expression
+    @Bean // dedicated bean to simplify SpEL expression
     fun opensearchIndexSubmitScheduledRepositoriesScanFixedDelay() = openSearchProperties?.index?.scan?.delay ?: 60000
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/VcsProperties.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/VcsProperties.kt
@@ -9,7 +9,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("vcs-facade.vcs")
 data class VcsProperties(
-    val services: List<Service>
+    val services: List<Service>,
 ) {
     data class Service(
         val id: String,
@@ -20,30 +20,31 @@ data class VcsProperties(
         val username: String?,
         val password: String?,
         val healthCheck: HealthCheck?,
-        val indexing: Boolean = true
+        val indexing: Boolean = true,
     ) {
-        fun getCredentialProvider() = if (token != null) {
-            if (type == VcsServiceType.BITBUCKET) {
-                BitbucketBearerTokenCredentialProvider(token)
+        fun getCredentialProvider() =
+            if (token != null) {
+                if (type == VcsServiceType.BITBUCKET) {
+                    BitbucketBearerTokenCredentialProvider(token)
+                } else {
+                    StandardBearerTokenCredentialProvider(token)
+                }
+            } else if (username != null && password != null) {
+                if (type == VcsServiceType.BITBUCKET) {
+                    BitbucketBasicCredentialProvider(username, password)
+                } else {
+                    StandardBasicCredCredentialProvider(username, password)
+                }
             } else {
-                StandardBearerTokenCredentialProvider(token)
+                throw IllegalStateException("Auth token or username/password must be specified")
             }
-        } else if (username != null && password != null) {
-            if (type == VcsServiceType.BITBUCKET) {
-                BitbucketBasicCredentialProvider(username, password)
-            } else {
-                StandardBasicCredCredentialProvider(username, password)
-            }
-        } else {
-            throw IllegalStateException("Auth token or username/password must be specified")
-        }
 
         data class HealthCheck(
             val group: String,
             val repository: String,
             val fromCommit: String,
             val toCommit: String,
-            val expectedCommits: Set<String>
+            val expectedCommits: Set<String>,
         )
     }
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/WebConfig.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/config/WebConfig.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.vcsfacade.config
 
-import java.net.InetAddress
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.actuate.info.Info
 import org.springframework.boot.actuate.info.InfoContributor
@@ -8,11 +7,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import java.net.InetAddress
 
 @Configuration
 class WebConfig(
-    @Value("\${vcs-facade.master}") val master: String
-) : WebMvcConfigurer, InfoContributor {
+    @Value("\${vcs-facade.master}") val master: String,
+) : WebMvcConfigurer,
+    InfoContributor {
     override fun addViewControllers(registry: ViewControllerRegistry) {
         registry.addRedirectViewController("/", "swagger-ui/index.html")
     }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/controller/ExceptionInfoHandler.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/controller/ExceptionInfoHandler.kt
@@ -53,8 +53,12 @@ class ExceptionInfoHandler {
     companion object {
         private val log: Logger = LoggerFactory.getLogger(ExceptionInfoHandler::class.java)
 
-        private fun handleError(errorCode: VcsFacadeErrorCode, exception: Exception) = ErrorResponse(
-            errorCode, exception.message ?: errorCode.defaultMessage
+        private fun handleError(
+            errorCode: VcsFacadeErrorCode,
+            exception: Exception,
+        ) = ErrorResponse(
+            errorCode,
+            exception.message ?: errorCode.defaultMessage,
         ).also {
             log.error(it.errorMessage, exception)
         }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/controller/IndexerController.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/controller/IndexerController.kt
@@ -2,8 +2,6 @@ package org.octopusden.octopus.vcsfacade.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
 import org.octopusden.octopus.vcsfacade.client.common.dto.IndexReport
 import org.octopusden.octopus.vcsfacade.config.OpenSearchConfig
 import org.octopusden.octopus.vcsfacade.dto.GiteaCreateRefEvent
@@ -20,17 +18,22 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
 @RestController
 @RequestMapping("rest/api/1/indexer")
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 class IndexerController(
     openSearchProperties: OpenSearchConfig.OpenSearchProperties,
     private val indexerService: IndexerService,
-    private val objectMapper: ObjectMapper
-) { //TODO: support BitBucket webhooks
+    private val objectMapper: ObjectMapper,
+) { // TODO: support BitBucket webhooks
     private val mac = openSearchProperties.index.webhookSecret?.let {
         Mac.getInstance(MAC_ALGORITHM).apply {
             init(SecretKeySpec(it.toByteArray(), MAC_ALGORITHM))
@@ -44,7 +47,7 @@ class IndexerController(
         @RequestHeader("x-gitea-event") event: String,
         @RequestHeader("x-gitea-event-type") eventType: String,
         @RequestHeader("x-gitea-signature") signature: String?,
-        request: HttpServletRequest
+        request: HttpServletRequest,
     ) {
         log.debug("Receive webhook event {}:{} from {}", event, eventType, vcsServiceId)
         val payload = request.inputStream.use { it.readAllBytes() }
@@ -70,8 +73,7 @@ class IndexerController(
                     ref,
                     refType.jsonValue,
                     vcsServiceId,
-                    repository.fullName
-
+                    repository.fullName,
                 )
                 indexerService.registerGiteaCreateRefEvent(vcsServiceId, this)
             }
@@ -82,7 +84,7 @@ class IndexerController(
                     ref,
                     refType.jsonValue,
                     vcsServiceId,
-                    repository.fullName
+                    repository.fullName,
                 )
                 indexerService.registerGiteaDeleteRefEvent(vcsServiceId, this)
             }
@@ -92,12 +94,15 @@ class IndexerController(
                     "Register {} commit(s) in {}:{} repository",
                     commits.size,
                     vcsServiceId,
-                    repository.fullName
+                    repository.fullName,
                 )
                 indexerService.registerGiteaPushEvent(vcsServiceId, this)
             }
         } else if (
-            (event == "pull_request" && (eventType == "pull_request" || eventType == "pull_request_assign" || eventType == "pull_request_review_request")) ||
+            (
+                event == "pull_request" &&
+                    (eventType == "pull_request" || eventType == "pull_request_assign" || eventType == "pull_request_review_request")
+            ) ||
             (event == "pull_request_approved" && eventType == "pull_request_review_approved") ||
             (event == "pull_request_rejected" && eventType == "pull_request_review_rejected")
         ) {
@@ -107,7 +112,7 @@ class IndexerController(
                     action,
                     pullRequest.number,
                     vcsServiceId,
-                    repository.fullName
+                    repository.fullName,
                 )
                 indexerService.registerGiteaPullRequestEvent(vcsServiceId, this)
             }
@@ -115,13 +120,17 @@ class IndexerController(
     }
 
     @PostMapping("scan")
-    fun scanRepository(@RequestParam("sshUrl") sshUrl: String) {
+    fun scanRepository(
+        @RequestParam("sshUrl") sshUrl: String,
+    ) {
         log.info("Schedule scan of {} repository", sshUrl)
         indexerService.scheduleRepositoryScan(sshUrl)
     }
 
     @GetMapping("report")
-    fun getIndexReport(@RequestParam("scanRequired") scanRequired : Boolean?): IndexReport {
+    fun getIndexReport(
+        @RequestParam("scanRequired") scanRequired: Boolean?,
+    ): IndexReport {
         log.info("Get repositories index report")
         return indexerService.getIndexReport(scanRequired)
     }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/controller/RepositoryController.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/controller/RepositoryController.kt
@@ -1,12 +1,5 @@
 package org.octopusden.octopus.vcsfacade.controller
 
-import java.util.Date
-import java.util.UUID
-import java.util.concurrent.Callable
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
 import org.octopusden.octopus.vcsfacade.client.common.Constants
 import org.octopusden.octopus.vcsfacade.client.common.dto.CommitWithFiles
 import org.octopusden.octopus.vcsfacade.client.common.dto.CreatePullRequest
@@ -31,14 +24,20 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-
+import java.util.Date
+import java.util.UUID
+import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 @RestController
 @RequestMapping("rest/api/2/repository")
 class RepositoryController(
     private val jobProperties: JobConfig.JobProperties,
     private val vcsManager: VcsManager,
-    @Qualifier("jobExecutor") private val jobExecutor: AsyncTaskExecutor
+    @Qualifier("jobExecutor") private val jobExecutor: AsyncTaskExecutor,
 ) {
     private val requestJobs = ConcurrentHashMap<String, Future<*>>()
 
@@ -48,13 +47,13 @@ class RepositoryController(
         @RequestParam("fromHashOrRef", required = false) fromHashOrRef: String?,
         @RequestParam("fromDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) fromDate: Date?,
         @RequestParam("toHashOrRef") toHashOrRef: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info(
             "Get commits ({},{}] in {} repository",
             (fromHashOrRef ?: fromDate?.toString()).orEmpty(),
             toHashOrRef,
-            sshUrl
+            sshUrl,
         )
         RepositoryResponse(vcsManager.getCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef))
     }.data.sorted()
@@ -66,18 +65,19 @@ class RepositoryController(
         @RequestParam("fromDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) fromDate: Date?,
         @RequestParam("toHashOrRef") toHashOrRef: String,
         @RequestParam("commitFilesLimit", defaultValue = "0") commitFilesLimit: Int,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info(
             "Get commits ({},{}] with files (limit {}) in {} repository",
             (fromHashOrRef ?: fromDate?.toString()).orEmpty(),
             toHashOrRef,
             commitFilesLimit,
-            sshUrl
+            sshUrl,
         )
         RepositoryResponse(
-            vcsManager.getCommitsWithFiles(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
-                .map { it.mapFilesList(commitFilesLimit) }
+            vcsManager
+                .getCommitsWithFiles(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
+                .map { it.mapFilesList(commitFilesLimit) },
         )
     }.data.sorted()
 
@@ -85,7 +85,7 @@ class RepositoryController(
     fun getCommit(
         @RequestParam("sshUrl") sshUrl: String,
         @RequestParam("hashOrRef") hashOrRef: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Get commit {} in {} repository", hashOrRef, sshUrl)
         vcsManager.getCommit(sshUrl, hashOrRef)
@@ -96,7 +96,7 @@ class RepositoryController(
         @RequestParam("sshUrl") sshUrl: String,
         @RequestParam("hashOrRef") hashOrRef: String,
         @RequestParam("commitFilesLimit", defaultValue = "0") commitFilesLimit: Int,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Get commit {} with files (limit {}) in {} repository", hashOrRef, commitFilesLimit, sshUrl)
         vcsManager.getCommitWithFiles(sshUrl, hashOrRef).mapFilesList(commitFilesLimit)
@@ -108,26 +108,27 @@ class RepositoryController(
         @RequestParam("fromHashOrRef", required = false) fromHashOrRef: String?,
         @RequestParam("fromDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) fromDate: Date?,
         @RequestParam("toHashOrRef") toHashOrRef: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info(
             "Find issue keys in commits ({},{}] in {} repository",
             (fromHashOrRef ?: fromDate?.toString()).orEmpty(),
             toHashOrRef,
-            sshUrl
+            sshUrl,
         )
         RepositoryResponse(
-            vcsManager.getCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
-                .flatMap { IssueKeyParser.findIssueKeys(it.message) }.distinct()
+            vcsManager
+                .getCommits(sshUrl, fromHashOrRef, fromDate, toHashOrRef)
+                .flatMap { IssueKeyParser.findIssueKeys(it.message) }
+                .distinct(),
         )
     }.data.sorted()
-
 
     @GetMapping("tags", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getTags(
         @RequestParam("sshUrl") sshUrl: String,
         @RequestParam("names", required = false) names: Set<String>?,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Get tags{} in {} repository", names?.joinToString(prefix = " with names {", postfix = "}") ?: "", sshUrl)
         RepositoryResponse(vcsManager.getTags(sshUrl, names))
@@ -137,7 +138,7 @@ class RepositoryController(
     fun createTag(
         @RequestParam("sshUrl") sshUrl: String,
         @RequestBody createTag: CreateTag,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Create tag {} on {} in {} repository", createTag.name, createTag.hashOrRef, sshUrl)
         vcsManager.createTag(sshUrl, createTag)
@@ -147,7 +148,7 @@ class RepositoryController(
     fun getTag(
         @RequestParam("sshUrl") sshUrl: String,
         @RequestParam("name") name: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Get tag {} in {} repository", name, sshUrl)
         vcsManager.getTag(sshUrl, name)
@@ -157,7 +158,7 @@ class RepositoryController(
     fun deleteTag(
         @RequestParam("sshUrl") sshUrl: String,
         @RequestParam("name") name: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Delete tag {} in {} repository", name, sshUrl)
         vcsManager.deleteTag(sshUrl, name)
@@ -166,11 +167,11 @@ class RepositoryController(
     @PostMapping(
         "search-issues-in-ranges",
         consumes = [MediaType.APPLICATION_JSON_VALUE],
-        produces = [MediaType.APPLICATION_JSON_VALUE]
+        produces = [MediaType.APPLICATION_JSON_VALUE],
     )
     fun searchIssuesInRanges(
         @RequestBody searchRequest: SearchIssuesInRangesRequest,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Search issue keys {} in specified commit ranges", searchRequest.issueKeys)
         vcsManager.searchIssuesInRanges(searchRequest)
@@ -179,18 +180,18 @@ class RepositoryController(
     @PostMapping(
         "pull-requests",
         consumes = [MediaType.APPLICATION_JSON_VALUE],
-        produces = [MediaType.APPLICATION_JSON_VALUE]
+        produces = [MediaType.APPLICATION_JSON_VALUE],
     )
     fun createPullRequest(
         @RequestParam("sshUrl") sshUrl: String,
         @RequestBody createPullRequest: CreatePullRequest,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info(
             "Create pull request ({} -> {}) in {} repository",
             sshUrl,
             createPullRequest.sourceBranch,
-            createPullRequest.targetBranch
+            createPullRequest.targetBranch,
         )
         vcsManager.createPullRequest(sshUrl, createPullRequest)
     }
@@ -198,7 +199,7 @@ class RepositoryController(
     @GetMapping("find", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findByIssueKeys(
         @RequestParam("issueKeys") issueKeys: Set<String>,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Get search summary for issue keys {}", issueKeys)
         vcsManager.find(issueKeys)
@@ -207,7 +208,7 @@ class RepositoryController(
     @GetMapping("branches/find", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findBranchesByIssueKeys(
         @RequestParam("issueKeys") issueKeys: Set<String>,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Find branches by issue keys {}", issueKeys)
         RepositoryResponse(vcsManager.findBranches(issueKeys))
@@ -216,7 +217,7 @@ class RepositoryController(
     @GetMapping("commits/find", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findCommitsByIssueKeys(
         @RequestParam("issueKeys") issueKeys: Set<String>,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Find commits by issue keys {}", issueKeys)
         RepositoryResponse(vcsManager.findCommits(issueKeys))
@@ -226,18 +227,18 @@ class RepositoryController(
     fun findCommitsWithFilesByIssueKeys(
         @RequestParam("issueKeys") issueKeys: Set<String>,
         @RequestParam("commitFilesLimit", defaultValue = "0") commitFilesLimit: Int,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Find commits with files (limit {}) by issue keys {}", commitFilesLimit, issueKeys)
         RepositoryResponse(
-            vcsManager.findCommitsWithFiles(issueKeys).map { it.mapFilesList(commitFilesLimit) }
+            vcsManager.findCommitsWithFiles(issueKeys).map { it.mapFilesList(commitFilesLimit) },
         )
     }.data.sorted()
 
     @GetMapping("pull-requests/find", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findPullRequestsByIssueKeys(
         @RequestParam("issueKeys") issueKeys: Set<String>,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.info("Find pull requests by issue keys {}", issueKeys)
         RepositoryResponse(vcsManager.findPullRequests(issueKeys))
@@ -245,12 +246,12 @@ class RepositoryController(
 
     @Deprecated(
         message = "Deprecated endpoint",
-        replaceWith = ReplaceWith("findByIssueKeys(listOf(issueKey), requestId)")
+        replaceWith = ReplaceWith("findByIssueKeys(listOf(issueKey), requestId)"),
     )
     @GetMapping("find/{issueKey}", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findByIssueKey(
         @PathVariable("issueKey") issueKey: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.warn("Deprecated call! Get search summary for issue key {}", issueKey)
         vcsManager.find(setOf(issueKey))
@@ -258,12 +259,12 @@ class RepositoryController(
 
     @Deprecated(
         message = "Deprecated endpoint",
-        replaceWith = ReplaceWith("findBranchesByIssueKeys(listOf(issueKey), requestId)")
+        replaceWith = ReplaceWith("findBranchesByIssueKeys(listOf(issueKey), requestId)"),
     )
     @GetMapping("find/{issueKey}/branches", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findBranchesByIssueKey(
         @PathVariable("issueKey") issueKey: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.warn("Deprecated call! Find branches by issue key {}", issueKey)
         RepositoryResponse(vcsManager.findBranches(setOf(issueKey)))
@@ -271,12 +272,12 @@ class RepositoryController(
 
     @Deprecated(
         message = "Deprecated endpoint",
-        replaceWith = ReplaceWith("findCommitsByIssueKeys(listOf(issueKey), requestId)")
+        replaceWith = ReplaceWith("findCommitsByIssueKeys(listOf(issueKey), requestId)"),
     )
     @GetMapping("find/{issueKey}/commits", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findCommitsByIssueKey(
         @PathVariable("issueKey") issueKey: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.warn("Deprecated call! Find commits by issue key {}", issueKey)
         RepositoryResponse(vcsManager.findCommits(setOf(issueKey)))
@@ -284,61 +285,69 @@ class RepositoryController(
 
     @Deprecated(
         message = "Deprecated endpoint",
-        replaceWith = ReplaceWith("findCommitsWithFilesByIssueKeys(listOf(issueKey), commitFilesLimit, requestId)")
+        replaceWith = ReplaceWith("findCommitsWithFilesByIssueKeys(listOf(issueKey), commitFilesLimit, requestId)"),
     )
     @GetMapping("find/{issueKey}/commits/files", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findCommitsWithFilesByIssueKey(
         @PathVariable("issueKey") issueKey: String,
         @RequestParam("commitFilesLimit", defaultValue = "0") commitFilesLimit: Int,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.warn("Deprecated call! Find commits with files (limit {}) by issue key {}", commitFilesLimit, issueKey)
         RepositoryResponse(
-            vcsManager.findCommitsWithFiles(setOf(issueKey)).map { it.mapFilesList(commitFilesLimit) }
+            vcsManager.findCommitsWithFiles(setOf(issueKey)).map { it.mapFilesList(commitFilesLimit) },
         )
     }.data.sorted()
 
     @Deprecated(
         message = "Deprecated endpoint",
-        replaceWith = ReplaceWith("findPullRequestsByIssueKeys(listOf(issueKey), requestId)")
+        replaceWith = ReplaceWith("findPullRequestsByIssueKeys(listOf(issueKey), requestId)"),
     )
     @GetMapping("find/{issueKey}/pull-requests", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun findPullRequestsByIssueKey(
         @PathVariable("issueKey") issueKey: String,
-        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?
+        @RequestHeader(Constants.DEFERRED_RESULT_HEADER, required = false) requestId: String?,
     ) = processRequest(requestId ?: UUID.randomUUID().toString()) {
         log.warn("Deprecated call! Find pull requests by issue key {}", issueKey)
         RepositoryResponse(vcsManager.findPullRequests(setOf(issueKey)))
     }.data.sorted()
 
-    private fun <T> processRequest(requestId: String, func: () -> T): T {
-        with(requestJobs.computeIfAbsent(requestId) { newRequest ->
-            log.debug("Submit request {}", newRequest)
-            val future = jobExecutor.submit(Callable {
-                log.trace("Start executing request {}", newRequest)
-                val result = func.invoke()
-                log.trace("Finish executing request {}", newRequest)
-                result
-            })
-            val waitThreshold = Date(Date().time + (jobProperties.fastWorkTimoutSecs * 1000))
-            while (Date().before(waitThreshold) && !future.isDone) {
-                TimeUnit.MILLISECONDS.sleep(200)
-            }
-            future
-        }) {
+    private fun <T> processRequest(
+        requestId: String,
+        func: () -> T,
+    ): T {
+        with(
+            requestJobs.computeIfAbsent(requestId) { newRequest ->
+                log.debug("Submit request {}", newRequest)
+                val future = jobExecutor.submit(
+                    Callable {
+                        log.trace("Start executing request {}", newRequest)
+                        val result = func.invoke()
+                        log.trace("Finish executing request {}", newRequest)
+                        result
+                    },
+                )
+                val waitThreshold = Date(Date().time + (jobProperties.fastWorkTimoutSecs * 1000))
+                while (Date().before(waitThreshold) && !future.isDone) {
+                    TimeUnit.MILLISECONDS.sleep(200)
+                }
+                future
+            },
+        ) {
             if (!isDone) {
                 throw JobProcessingException(
                     "Request $requestId is still processing",
                     requestId,
-                    Date(Date().time + (jobProperties.retryIntervalSecs * 1000))
+                    Date(Date().time + (jobProperties.retryIntervalSecs * 1000)),
                 )
             }
         }
         log.debug("Collect request {} result", requestId)
         try {
-            //TODO: use some concurrent map with timed entry eviction
-            //Repeatable deferred result request could be routed to another instance if application runs in multi-nodes
-            @Suppress("UNCHECKED_CAST") return requestJobs.remove(requestId)!!.get() as T
+            // TODO: use some concurrent map with timed entry eviction
+            // Repeatable deferred result request could be routed to another instance if application runs in multi-nodes
+            @Suppress("UNCHECKED_CAST")
+            return requestJobs.remove(requestId)!!.get() as T
         } catch (e: ExecutionException) {
             throw e.cause!!
         }
@@ -347,8 +356,9 @@ class RepositoryController(
     companion object {
         private val log = LoggerFactory.getLogger(RepositoryController::class.java)
 
-        private fun CommitWithFiles.mapFilesList(commitFilesLimit: Int) = files.sorted().let {
-            CommitWithFiles(commit, totalFiles, if (commitFilesLimit > 0) it.take(commitFilesLimit) else it)
-        }
+        private fun CommitWithFiles.mapFilesList(commitFilesLimit: Int) =
+            files.sorted().let {
+                CommitWithFiles(commit, totalFiles, if (commitFilesLimit > 0) it.take(commitFilesLimit) else it)
+            }
     }
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/BaseDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/BaseDocument.kt
@@ -7,7 +7,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType
 abstract class BaseDocument(
     @Id
     @Field(type = FieldType.Keyword)
-    val id: String
+    val id: String,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/CommitDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/CommitDocument.kt
@@ -1,16 +1,19 @@
 package org.octopusden.octopus.vcsfacade.document
 
-import java.util.Date
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.elasticsearch.annotations.Document
 import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
 import org.springframework.data.elasticsearch.annotations.Setting
+import java.util.Date
 
 @Document(indexName = "#{ 'vcs-facade-commits-' + @opensearchIndexSuffix }")
 @Setting(settingPath = "opensearch-index-settings.json")
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 class CommitDocument(
     @Field(type = FieldType.Object) val repository: RepositoryDocument,
@@ -20,13 +23,16 @@ class CommitDocument(
     @Field(type = FieldType.Object) val author: UserDocument,
     @Field(type = FieldType.Keyword) val parents: List<String>,
     @Field(type = FieldType.Keyword) val link: String,
-    //TODO: Sometimes a commit contains enormous number of affected files. Is it better to store files in separate index?
-    @Field(type = FieldType.Object) val files: List<FileChangeDocument>
+    // TODO: Sometimes a commit contains enormous number of affected files. Is it better to store files in separate index?
+    @Field(type = FieldType.Object) val files: List<FileChangeDocument>,
 ) : BaseDocument(commitId(repository, hash)) {
     override fun toString() =
         "CommitDocument(id=$id, repository=$repository, hash=$hash, message=$message, date=$date, author=$author, parents=$parents, link=$link)"
 
     companion object {
-        fun commitId(repository: RepositoryDocument, hash: String) = id(repository.id, hash)
+        fun commitId(
+            repository: RepositoryDocument,
+            hash: String,
+        ) = id(repository.id, hash)
     }
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/FileChangeDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/FileChangeDocument.kt
@@ -7,5 +7,5 @@ import org.springframework.data.elasticsearch.annotations.FieldType
 data class FileChangeDocument(
     @Field(type = FieldType.Keyword) val type: FileChangeType,
     @Field(type = FieldType.Text, analyzer = "classic") val path: String,
-    @Field(type = FieldType.Keyword) val link: String
+    @Field(type = FieldType.Keyword) val link: String,
 )

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/PullRequestDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/PullRequestDocument.kt
@@ -1,17 +1,20 @@
 package org.octopusden.octopus.vcsfacade.document
 
-import java.util.Date
 import org.octopusden.octopus.vcsfacade.client.common.dto.PullRequestStatus
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.elasticsearch.annotations.Document
 import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
 import org.springframework.data.elasticsearch.annotations.Setting
+import java.util.Date
 
 @Document(indexName = "#{ 'vcs-facade-pull-requests-' + @opensearchIndexSuffix }")
 @Setting(settingPath = "opensearch-index-settings.json")
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 class PullRequestDocument(
     @Field(type = FieldType.Object) val repository: RepositoryDocument,
@@ -26,7 +29,7 @@ class PullRequestDocument(
     @Field(type = FieldType.Keyword) val status: PullRequestStatus,
     @Field(type = FieldType.Date) val createdAt: Date,
     @Field(type = FieldType.Date) val updatedAt: Date,
-    @Field(type = FieldType.Keyword) val link: String
+    @Field(type = FieldType.Keyword) val link: String,
 ) : BaseDocument(id(repository.id, index)) {
     override fun toString() =
         "PullRequestDocument(id=$id, repository=$repository, index=$index, title=$title, description=$description, author=$author, source=$source, target=$target, assignees=$assignees, reviewers=$reviewers, status=$status, createdAt=$createdAt, updatedAt=$updatedAt, link=$link)"

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/PullRequestReviewerDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/PullRequestReviewerDocument.kt
@@ -5,5 +5,5 @@ import org.springframework.data.elasticsearch.annotations.FieldType
 
 data class PullRequestReviewerDocument(
     @Field(type = FieldType.Object) val user: UserDocument,
-    @Field(type = FieldType.Boolean) val approved: Boolean
+    @Field(type = FieldType.Boolean) val approved: Boolean,
 )

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/RefDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/RefDocument.kt
@@ -10,17 +10,19 @@ import org.springframework.data.elasticsearch.annotations.Setting
 @Document(indexName = "#{ 'vcs-facade-refs-' + @opensearchIndexSuffix }")
 @Setting(settingPath = "opensearch-index-settings.json")
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 class RefDocument(
     @Field(type = FieldType.Object) val repository: RepositoryDocument,
     @Field(type = FieldType.Keyword) val type: RefType,
     @Field(type = FieldType.Text, analyzer = "classic") val name: String,
     @Field(type = FieldType.Keyword) val hash: String,
-    @Field(type = FieldType.Keyword) val link: String
+    @Field(type = FieldType.Keyword) val link: String,
 ) : BaseDocument(id(repository.id, type, name)) {
     val commitId = id(repository.id, hash)
 
-    override fun toString() =
-        "RefDocument(id=$id, repository=$repository, type=$type, name=$name, hash=$hash, link=$link)"
+    override fun toString() = "RefDocument(id=$id, repository=$repository, type=$type, name=$name, hash=$hash, link=$link)"
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/RepositoryDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/RepositoryDocument.kt
@@ -3,14 +3,13 @@ package org.octopusden.octopus.vcsfacade.document
 import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
 
-
 class RepositoryDocument(
     @Field(type = FieldType.Keyword) val vcsServiceId: String,
     @Field(type = FieldType.Keyword) val group: String,
     @Field(type = FieldType.Keyword) val name: String,
     @Field(type = FieldType.Keyword) val sshUrl: String,
     @Field(type = FieldType.Keyword) val link: String,
-    @Field(type = FieldType.Keyword) val avatar: String?
+    @Field(type = FieldType.Keyword) val avatar: String?,
 ) : BaseDocument(id(vcsServiceId, group, name)) {
     override fun toString() =
         "RepositoryDocument(id=$id, vcsServiceId=$vcsServiceId, group=$group, name=$name, sshUrl=$sshUrl, link=$link, avatar=$avatar)"

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/RepositoryInfoDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/RepositoryInfoDocument.kt
@@ -1,22 +1,24 @@
 package org.octopusden.octopus.vcsfacade.document
 
-import java.util.Date
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.elasticsearch.annotations.Document
 import org.springframework.data.elasticsearch.annotations.Field
 import org.springframework.data.elasticsearch.annotations.FieldType
 import org.springframework.data.elasticsearch.annotations.Setting
+import java.util.Date
 
 @Document(indexName = "#{ 'vcs-facade-repositories-' + @opensearchIndexSuffix }")
 @Setting(settingPath = "opensearch-index-settings.json")
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 class RepositoryInfoDocument(
     @Field(type = FieldType.Object) val repository: RepositoryDocument,
     @Field(type = FieldType.Boolean) var scanRequired: Boolean = true,
-    @Field(type = FieldType.Date) var lastScanAt: Date? = null
+    @Field(type = FieldType.Date) var lastScanAt: Date? = null,
 ) : BaseDocument(id(repository.id)) {
-    override fun toString() =
-        "RepositoryInfoDocument(id=$id, repository=$repository, scanRequired=$scanRequired, lastScanAt=$lastScanAt)"
+    override fun toString() = "RepositoryInfoDocument(id=$id, repository=$repository, scanRequired=$scanRequired, lastScanAt=$lastScanAt)"
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/UserDocument.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/document/UserDocument.kt
@@ -5,5 +5,5 @@ import org.springframework.data.elasticsearch.annotations.FieldType
 
 data class UserDocument(
     @Field(type = FieldType.Keyword) val name: String,
-    @Field(type = FieldType.Keyword) val avatar: String?
+    @Field(type = FieldType.Keyword) val avatar: String?,
 )

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaCreateRefEvent.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaCreateRefEvent.kt
@@ -9,5 +9,5 @@ data class GiteaCreateRefEvent(
     val refType: GiteaRefType,
     val ref: String,
     val repository: GiteaRepository,
-    val sha: String
+    val sha: String,
 )

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaDeleteRefEvent.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaDeleteRefEvent.kt
@@ -8,5 +8,5 @@ import org.octopusden.octopus.infrastructure.gitea.client.dto.GiteaRepository
 data class GiteaDeleteRefEvent(
     val refType: GiteaRefType,
     val ref: String,
-    val repository: GiteaRepository
+    val repository: GiteaRepository,
 )

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaPullRequestEvent.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaPullRequestEvent.kt
@@ -9,5 +9,5 @@ import org.octopusden.octopus.infrastructure.gitea.client.dto.GiteaRepository
 data class GiteaPullRequestEvent(
     val action: String,
     val pullRequest: GiteaPullRequest,
-    val repository: GiteaRepository
+    val repository: GiteaRepository,
 )

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaPushEvent.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaPushEvent.kt
@@ -5,5 +5,5 @@ import org.octopusden.octopus.infrastructure.gitea.client.dto.GiteaRepository
 
 data class GiteaPushEvent(
     val commits: List<GiteaBranch.PayloadCommit>,
-    val repository: GiteaRepository
+    val repository: GiteaRepository,
 )

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaRefType.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/GiteaRefType.kt
@@ -6,7 +6,8 @@ import org.octopusden.octopus.vcsfacade.client.common.dto.RefType
 enum class GiteaRefType(
     @get:JsonValue
     val jsonValue: String,
-    val refType: RefType
+    val refType: RefType,
 ) {
-    BRANCH("branch", RefType.BRANCH), TAG("tag", RefType.TAG)
+    BRANCH("branch", RefType.BRANCH),
+    TAG("tag", RefType.TAG),
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/HashOrRefOrDate.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/HashOrRefOrDate.kt
@@ -1,25 +1,34 @@
 package org.octopusden.octopus.vcsfacade.dto
 
-import java.util.Date
 import org.octopusden.octopus.vcsfacade.client.common.exception.ArgumentsNotCompatibleException
+import java.util.Date
 
 sealed class HashOrRefOrDate<out String, out Date> {
-    class HashOrRefValue(val value: String) : HashOrRefOrDate<String, Nothing>() {
+    class HashOrRefValue(
+        val value: String,
+    ) : HashOrRefOrDate<String, Nothing>() {
         override fun toString() = value
     }
 
-    class DateValue(val value: Date) : HashOrRefOrDate<Nothing, Date>() {
+    class DateValue(
+        val value: Date,
+    ) : HashOrRefOrDate<Nothing, Date>() {
         override fun toString() = value.toString()
     }
 
     companion object {
-        fun create(hashOrRef: String?, date: Date?) = if (hashOrRef != null) {
+        fun create(
+            hashOrRef: String?,
+            date: Date?,
+        ) = if (hashOrRef != null) {
             if (date != null) {
                 throw ArgumentsNotCompatibleException("'hashOrRef' and 'date' can not be used together")
             }
             HashOrRefValue(hashOrRef)
         } else if (date != null) {
             DateValue(date)
-        } else null
+        } else {
+            null
+        }
     }
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/RepositoryResponse.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/RepositoryResponse.kt
@@ -1,3 +1,5 @@
 package org.octopusden.octopus.vcsfacade.dto
 
-data class RepositoryResponse<T>(val data: Sequence<T>)
+data class RepositoryResponse<T>(
+    val data: Sequence<T>,
+)

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/VcsServiceType.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/dto/VcsServiceType.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.vcsfacade.dto
 
 enum class VcsServiceType {
-    BITBUCKET, GITEA
+    BITBUCKET,
+    GITEA,
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/exception/InvalidSignatureException.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/exception/InvalidSignatureException.kt
@@ -2,4 +2,6 @@ package org.octopusden.octopus.vcsfacade.exception
 
 import org.octopusden.octopus.vcsfacade.client.common.exception.VcsFacadeException
 
-class InvalidSignatureException(message: String) : VcsFacadeException(message)
+class InvalidSignatureException(
+    message: String,
+) : VcsFacadeException(message)

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/exception/JobProcessingException.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/exception/JobProcessingException.kt
@@ -3,4 +3,8 @@ package org.octopusden.octopus.vcsfacade.exception
 import org.octopusden.octopus.vcsfacade.client.common.exception.VcsFacadeException
 import java.util.Date
 
-class JobProcessingException(message: String, val requestId: String, val retryAfter: Date) : VcsFacadeException(message)
+class JobProcessingException(
+    message: String,
+    val requestId: String,
+    val retryAfter: Date,
+) : VcsFacadeException(message)

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/issue/IssueKeyParser.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/issue/IssueKeyParser.kt
@@ -7,11 +7,14 @@ object IssueKeyParser {
 
     private val issueKeyValidateRegex = ISSUE_KEY_PATTERN.toRegex()
 
-    fun validateIssueKeys(issueKeys: Set<String>) = issueKeys.filter { !it.matches(issueKeyValidateRegex) }.let {
-        if (it.isNotEmpty()) throw ArgumentsNotCompatibleException(
-            it.sorted().joinToString(", ", "Invalid issue keys: ") { issueKey -> "'$issueKey'" }
-        )
-    }
+    fun validateIssueKeys(issueKeys: Set<String>) =
+        issueKeys.filter { !it.matches(issueKeyValidateRegex) }.let {
+            if (it.isNotEmpty()) {
+                throw ArgumentsNotCompatibleException(
+                    it.sorted().joinToString(", ", "Invalid issue keys: ") { issueKey -> "'$issueKey'" },
+                )
+            }
+        }
 
     private val issueKeyFindRegex = "(?:^|[^_A-Z0-9])($ISSUE_KEY_PATTERN)".toRegex()
 

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/repository/CommitRepository.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/repository/CommitRepository.kt
@@ -5,10 +5,18 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.repository.CrudRepository
 
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 interface CommitRepository : CrudRepository<CommitDocument, String> {
     fun searchByMessageContaining(messageToken: String): List<CommitDocument>
-    fun searchFirst50ByRepositoryIdAndIdAfterOrderByIdAsc(repositoryId: String, id: String): List<CommitDocument>
+
+    fun searchFirst50ByRepositoryIdAndIdAfterOrderByIdAsc(
+        repositoryId: String,
+        id: String,
+    ): List<CommitDocument>
+
     fun deleteByRepositoryId(repositoryId: String)
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/repository/PullRequestRepository.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/repository/PullRequestRepository.kt
@@ -5,10 +5,21 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.repository.CrudRepository
 
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 interface PullRequestRepository : CrudRepository<PullRequestDocument, String> {
-    fun searchByTitleContainingOrDescriptionContaining(titleToken: String, descriptionToken: String): List<PullRequestDocument>
-    fun searchFirst50ByRepositoryIdAndIdAfterOrderByIdAsc(repositoryId: String, id: String): List<PullRequestDocument>
+    fun searchByTitleContainingOrDescriptionContaining(
+        titleToken: String,
+        descriptionToken: String,
+    ): List<PullRequestDocument>
+
+    fun searchFirst50ByRepositoryIdAndIdAfterOrderByIdAsc(
+        repositoryId: String,
+        id: String,
+    ): List<PullRequestDocument>
+
     fun deleteByRepositoryId(repositoryId: String)
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/repository/RefRepository.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/repository/RefRepository.kt
@@ -6,10 +6,21 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.repository.CrudRepository
 
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 interface RefRepository : CrudRepository<RefDocument, String> {
-    fun searchByTypeAndNameContaining(type: RefType, nameToken: String): List<RefDocument>
-    fun searchFirst50ByRepositoryIdAndIdAfterOrderByIdAsc(repositoryId: String, id: String): List<RefDocument>
+    fun searchByTypeAndNameContaining(
+        type: RefType,
+        nameToken: String,
+    ): List<RefDocument>
+
+    fun searchFirst50ByRepositoryIdAndIdAfterOrderByIdAsc(
+        repositoryId: String,
+        id: String,
+    ): List<RefDocument>
+
     fun deleteByRepositoryId(repositoryId: String)
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/repository/RepositoryInfoRepository.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/repository/RepositoryInfoRepository.kt
@@ -5,9 +5,16 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.repository.CrudRepository
 
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 interface RepositoryInfoRepository : CrudRepository<RepositoryInfoDocument, String> {
     fun searchFirst50ByIdAfterOrderByIdAsc(id: String): List<RepositoryInfoDocument>
-    fun searchFirst50ByScanRequiredAndIdAfterOrderByIdAsc(scanRequired: Boolean, id: String): List<RepositoryInfoDocument>
+
+    fun searchFirst50ByScanRequiredAndIdAfterOrderByIdAsc(
+        scanRequired: Boolean,
+        id: String,
+    ): List<RepositoryInfoDocument>
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/IndexerService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/IndexerService.kt
@@ -7,10 +7,27 @@ import org.octopusden.octopus.vcsfacade.dto.GiteaPullRequestEvent
 import org.octopusden.octopus.vcsfacade.dto.GiteaPushEvent
 
 interface IndexerService {
-    fun registerGiteaCreateRefEvent(vcsServiceId: String, createRefEvent: GiteaCreateRefEvent)
-    fun registerGiteaDeleteRefEvent(vcsServiceId: String, deleteRefEvent: GiteaDeleteRefEvent)
-    fun registerGiteaPushEvent(vcsServiceId: String, pushEvent: GiteaPushEvent)
-    fun registerGiteaPullRequestEvent(vcsServiceId: String, pullRequestEvent: GiteaPullRequestEvent)
+    fun registerGiteaCreateRefEvent(
+        vcsServiceId: String,
+        createRefEvent: GiteaCreateRefEvent,
+    )
+
+    fun registerGiteaDeleteRefEvent(
+        vcsServiceId: String,
+        deleteRefEvent: GiteaDeleteRefEvent,
+    )
+
+    fun registerGiteaPushEvent(
+        vcsServiceId: String,
+        pushEvent: GiteaPushEvent,
+    )
+
+    fun registerGiteaPullRequestEvent(
+        vcsServiceId: String,
+        pullRequestEvent: GiteaPullRequestEvent,
+    )
+
     fun scheduleRepositoryScan(sshUrl: String)
+
     fun getIndexReport(scanRequired: Boolean?): IndexReport
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/OpenSearchService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/OpenSearchService.kt
@@ -21,82 +21,108 @@ import org.octopusden.octopus.vcsfacade.document.RepositoryDocument
 import org.octopusden.octopus.vcsfacade.document.RepositoryInfoDocument
 import org.octopusden.octopus.vcsfacade.document.UserDocument
 
-
 interface OpenSearchService {
     fun getRepositoriesInfo(scanRequired: Boolean? = null): Set<RepositoryInfoDocument>
+
     fun findRepositoryInfoById(repositoryId: String): RepositoryInfoDocument?
+
     fun saveRepositoriesInfo(repositoriesInfo: Sequence<RepositoryInfoDocument>): Set<String>
+
     fun deleteRepositoryInfoById(repositoryId: String)
+
     fun findRefsIdsByRepositoryId(repositoryId: String): Set<String>
+
     fun saveRefs(refs: Sequence<RefDocument>): Set<String>
+
     fun deleteRefsByIds(refsIds: Set<String>)
+
     fun deleteRefsByRepositoryId(repositoryId: String)
+
     fun findCommitsIdsByRepositoryId(repositoryId: String): Set<String>
+
     fun saveCommits(commits: Sequence<CommitDocument>): Set<String>
+
     fun deleteCommitsByIds(commitsIds: Set<String>)
+
     fun deleteCommitsByRepositoryId(repositoryId: String)
+
     fun findPullRequestsIdsByRepositoryId(repositoryId: String): Set<String>
+
     fun savePullRequests(pullRequests: Sequence<PullRequestDocument>): Set<String>
+
     fun deletePullRequestsByIds(pullRequestsIds: Set<String>)
+
     fun deletePullRequestsByRepositoryId(repositoryId: String)
+
     fun findBranchesByIssueKeys(issueKeys: Set<String>): Set<RefDocument>
+
     fun findCommitsByIssueKeys(issueKeys: Set<String>): Set<CommitDocument>
+
     fun findPullRequestsByIssueKeys(issueKeys: Set<String>): Set<PullRequestDocument>
+
     fun findByIssueKeys(issueKeys: Set<String>): SearchSummary
 
     companion object {
-        fun Ref.toDocument(repositoryDocument: RepositoryDocument) =
-            RefDocument(repositoryDocument, type, name, hash, link)
+        fun Ref.toDocument(repositoryDocument: RepositoryDocument) = RefDocument(repositoryDocument, type, name, hash, link)
 
-        fun RefDocument.toDto() = when (type) {
-            RefType.BRANCH -> Branch(name, hash, link, repository.toDto())
-            RefType.TAG -> Tag(name, hash, link, repository.toDto())
-        }
+        fun RefDocument.toDto() =
+            when (type) {
+                RefType.BRANCH -> Branch(name, hash, link, repository.toDto())
+                RefType.TAG -> Tag(name, hash, link, repository.toDto())
+            }
 
-        fun CommitWithFiles.toDocument(repositoryDocument: RepositoryDocument) = CommitDocument(repositoryDocument,
-            commit.hash,
-            commit.message,
-            commit.date,
-            commit.author.toDocument(),
-            commit.parents,
-            commit.link,
-            files.map { it.toDocument() })
+        fun CommitWithFiles.toDocument(repositoryDocument: RepositoryDocument) =
+            CommitDocument(
+                repositoryDocument,
+                commit.hash,
+                commit.message,
+                commit.date,
+                commit.author.toDocument(),
+                commit.parents,
+                commit.link,
+                files.map { it.toDocument() },
+            )
 
         fun CommitDocument.toDto() =
-            CommitWithFiles(Commit(hash, message, date, author.toDto(), parents, link, repository.toDto()),
+            CommitWithFiles(
+                Commit(hash, message, date, author.toDto(), parents, link, repository.toDto()),
                 files.size,
-                files.map { it.toDto() })
+                files.map { it.toDto() },
+            )
 
-        fun PullRequest.toDocument(repositoryDocument: RepositoryDocument) = PullRequestDocument(
-            repositoryDocument,
-            index,
-            title,
-            description,
-            author.toDocument(),
-            source,
-            target,
-            assignees.map { it.toDocument() },
-            reviewers.map { it.toDocument() },
-            status,
-            createdAt,
-            updatedAt,
-            link
-        )
+        fun PullRequest.toDocument(repositoryDocument: RepositoryDocument) =
+            PullRequestDocument(
+                repositoryDocument,
+                index,
+                title,
+                description,
+                author.toDocument(),
+                source,
+                target,
+                assignees.map { it.toDocument() },
+                reviewers.map { it.toDocument() },
+                status,
+                createdAt,
+                updatedAt,
+                link,
+            )
 
-        fun PullRequestDocument.toDto() = PullRequest(index,
-            title,
-            description,
-            author.toDto(),
-            source,
-            target,
-            assignees.map { it.toDto() },
-            reviewers.map { it.toDto() },
-            status,
-            createdAt,
-            updatedAt,
-            link,
-            repository.toDto()
-        )
+        fun PullRequestDocument.toDto() =
+            PullRequest(
+                index,
+                title,
+                description,
+                author.toDto(),
+                source,
+                target,
+                assignees.map { it.toDto() },
+                reviewers.map { it.toDto() },
+                status,
+                createdAt,
+                updatedAt,
+                link,
+                repository.toDto(),
+            )
 
         private fun PullRequestReviewer.toDocument() = PullRequestReviewerDocument(user.toDocument(), approved)
 

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsManager.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsManager.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.vcsfacade.service
 
-import java.util.Date
 import org.octopusden.octopus.vcsfacade.client.common.dto.Branch
 import org.octopusden.octopus.vcsfacade.client.common.dto.Commit
 import org.octopusden.octopus.vcsfacade.client.common.dto.CommitWithFiles
@@ -11,31 +10,75 @@ import org.octopusden.octopus.vcsfacade.client.common.dto.SearchIssueInRangesRes
 import org.octopusden.octopus.vcsfacade.client.common.dto.SearchIssuesInRangesRequest
 import org.octopusden.octopus.vcsfacade.client.common.dto.SearchSummary
 import org.octopusden.octopus.vcsfacade.client.common.dto.Tag
+import java.util.Date
 
-interface VcsManager { //TODO: allow to use both http and ssh repository url (renaming `sshUrl` to `repositoryUrl`)
+interface VcsManager { // TODO: allow to use both http and ssh repository url (renaming `sshUrl` to `repositoryUrl`)
     val vcsServices: Collection<VcsService>
+
     fun findVcsServiceById(id: String): VcsService?
+
     fun getVcsServiceById(id: String): VcsService
+
     fun getVcsServiceForSshUrl(sshUrl: String): VcsService
-    fun getTags(sshUrl: String, names: Set<String>?): Sequence<Tag>
-    fun createTag(sshUrl: String, createTag: CreateTag): Tag
-    fun getTag(sshUrl: String, name: String): Tag
-    fun deleteTag(sshUrl: String, name: String)
-    fun getCommits(sshUrl: String, fromHashOrRef: String?, fromDate: Date?, toHashOrRef: String): Sequence<Commit>
+
+    fun getTags(
+        sshUrl: String,
+        names: Set<String>?,
+    ): Sequence<Tag>
+
+    fun createTag(
+        sshUrl: String,
+        createTag: CreateTag,
+    ): Tag
+
+    fun getTag(
+        sshUrl: String,
+        name: String,
+    ): Tag
+
+    fun deleteTag(
+        sshUrl: String,
+        name: String,
+    )
+
+    fun getCommits(
+        sshUrl: String,
+        fromHashOrRef: String?,
+        fromDate: Date?,
+        toHashOrRef: String,
+    ): Sequence<Commit>
+
     fun getCommitsWithFiles(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ): Sequence<CommitWithFiles>
 
-    fun getCommit(sshUrl: String, hashOrRef: String): Commit
-    fun getCommitWithFiles(sshUrl: String, hashOrRef: String): CommitWithFiles
-    fun createPullRequest(sshUrl: String, createPullRequest: CreatePullRequest): PullRequest
+    fun getCommit(
+        sshUrl: String,
+        hashOrRef: String,
+    ): Commit
+
+    fun getCommitWithFiles(
+        sshUrl: String,
+        hashOrRef: String,
+    ): CommitWithFiles
+
+    fun createPullRequest(
+        sshUrl: String,
+        createPullRequest: CreatePullRequest,
+    ): PullRequest
+
     fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest): SearchIssueInRangesResponse
+
     fun findBranches(issueKeys: Set<String>): Sequence<Branch>
+
     fun findCommits(issueKeys: Set<String>): Sequence<Commit>
+
     fun findCommitsWithFiles(issueKeys: Set<String>): Sequence<CommitWithFiles>
+
     fun findPullRequests(issueKeys: Set<String>): Sequence<PullRequest>
+
     fun find(issueKeys: Set<String>): SearchSummary
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/VcsService.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.vcsfacade.service
 
-import java.util.Date
 import org.octopusden.octopus.vcsfacade.client.common.dto.Branch
 import org.octopusden.octopus.vcsfacade.client.common.dto.Commit
 import org.octopusden.octopus.vcsfacade.client.common.dto.CommitWithFiles
@@ -12,51 +11,133 @@ import org.octopusden.octopus.vcsfacade.client.common.dto.Tag
 import org.octopusden.octopus.vcsfacade.config.VcsProperties
 import org.octopusden.octopus.vcsfacade.dto.HashOrRefOrDate
 import org.octopusden.octopus.vcsfacade.dto.VcsServiceType
+import java.util.Date
 
-abstract class VcsService(vcsServiceProperties: VcsProperties.Service) {
+abstract class VcsService(
+    vcsServiceProperties: VcsProperties.Service,
+) {
     val id = vcsServiceProperties.id.lowercase()
     val type = vcsServiceProperties.type
     val indexing = vcsServiceProperties.indexing
     protected val httpUrl = vcsServiceProperties.httpUrl.lowercase().trimEnd('/')
     protected val sshUrl = vcsServiceProperties.sshUrl.lowercase().trimEnd(':', '/')
-    private val sshUrlRegex = "${Regex.escape(sshUrl)}[:/]${if (type == VcsServiceType.BITBUCKET) "(?:scm/)?" else ""}((?:[^/]+/)+)([^/]+)\\.git".toRegex()
+    private val sshUrlRegex = "${Regex.escape(
+        sshUrl,
+    )}[:/]${if (type == VcsServiceType.BITBUCKET) "(?:scm/)?" else ""}((?:[^/]+/)+)([^/]+)\\.git".toRegex()
+
     fun isSupported(sshUrl: String) = sshUrlRegex.matches(sshUrl.lowercase())
-    fun parse(sshUrl: String) = sshUrlRegex.find(sshUrl.lowercase())!!.destructured.let {
-        it.component1().trimEnd('/') to it.component2()
-    }
+
+    fun parse(sshUrl: String) =
+        sshUrlRegex.find(sshUrl.lowercase())!!.destructured.let {
+            it.component1().trimEnd('/') to it.component2()
+        }
 
     abstract fun getRepositories(): Sequence<Repository>
-    abstract fun findRepository(group: String, repository: String): Repository?
-    abstract fun getBranches(group: String, repository: String): Sequence<Branch>
-    abstract fun getTags(group: String, repository: String): Sequence<Tag>
-    abstract fun createTag(group: String, repository: String, createTag: CreateTag): Tag
-    abstract fun getTag(group: String, repository: String, name: String): Tag
-    abstract fun deleteTag(group: String, repository: String, name: String)
+
+    abstract fun findRepository(
+        group: String,
+        repository: String,
+    ): Repository?
+
+    abstract fun getBranches(
+        group: String,
+        repository: String,
+    ): Sequence<Branch>
+
+    abstract fun getTags(
+        group: String,
+        repository: String,
+    ): Sequence<Tag>
+
+    abstract fun createTag(
+        group: String,
+        repository: String,
+        createTag: CreateTag,
+    ): Tag
+
+    abstract fun getTag(
+        group: String,
+        repository: String,
+        name: String,
+    ): Tag
+
+    abstract fun deleteTag(
+        group: String,
+        repository: String,
+        name: String,
+    )
+
     abstract fun getCommits(
         group: String,
         repository: String,
         from: HashOrRefOrDate<String, Date>?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ): Sequence<Commit>
 
     abstract fun getCommitsWithFiles(
         group: String,
         repository: String,
         from: HashOrRefOrDate<String, Date>?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ): Sequence<CommitWithFiles>
 
-    abstract fun getBranchesCommitGraph(group: String, repository: String): Sequence<CommitWithFiles>
-    abstract fun getCommit(group: String, repository: String, hashOrRef: String): Commit
-    abstract fun getCommitWithFiles(group: String, repository: String, hashOrRef: String): CommitWithFiles
-    abstract fun getPullRequests(group: String, repository: String): Sequence<PullRequest>
-    abstract fun createPullRequest(group: String, repository: String, createPullRequest: CreatePullRequest): PullRequest
-    abstract fun getPullRequest(group: String, repository: String, index: Long): PullRequest
-    abstract fun findTags(group: String, repository: String, names: Set<String>): Sequence<Tag>
-    abstract fun findCommits(group: String, repository: String, hashes: Set<String>): Sequence<Commit>
-    abstract fun findPullRequests(group: String, repository: String, indexes: Set<Long>): Sequence<PullRequest>
+    abstract fun getBranchesCommitGraph(
+        group: String,
+        repository: String,
+    ): Sequence<CommitWithFiles>
+
+    abstract fun getCommit(
+        group: String,
+        repository: String,
+        hashOrRef: String,
+    ): Commit
+
+    abstract fun getCommitWithFiles(
+        group: String,
+        repository: String,
+        hashOrRef: String,
+    ): CommitWithFiles
+
+    abstract fun getPullRequests(
+        group: String,
+        repository: String,
+    ): Sequence<PullRequest>
+
+    abstract fun createPullRequest(
+        group: String,
+        repository: String,
+        createPullRequest: CreatePullRequest,
+    ): PullRequest
+
+    abstract fun getPullRequest(
+        group: String,
+        repository: String,
+        index: Long,
+    ): PullRequest
+
+    abstract fun findTags(
+        group: String,
+        repository: String,
+        names: Set<String>,
+    ): Sequence<Tag>
+
+    abstract fun findCommits(
+        group: String,
+        repository: String,
+        hashes: Set<String>,
+    ): Sequence<Commit>
+
+    abstract fun findPullRequests(
+        group: String,
+        repository: String,
+        indexes: Set<Long>,
+    ): Sequence<PullRequest>
+
     abstract fun findBranches(issueKey: String): Sequence<Branch>
+
     abstract fun findCommits(issueKey: String): Sequence<Commit>
+
     abstract fun findCommitsWithFiles(issueKey: String): Sequence<CommitWithFiles>
+
     abstract fun findPullRequests(issueKey: String): Sequence<PullRequest>
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/BitbucketService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/BitbucketService.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.vcsfacade.service.impl
 
-import java.util.Date
 import org.octopusden.octopus.infrastructure.bitbucket.client.BitbucketClassicClient
 import org.octopusden.octopus.infrastructure.bitbucket.client.BitbucketClient
 import org.octopusden.octopus.infrastructure.bitbucket.client.BitbucketClientParametersProvider
@@ -40,22 +39,30 @@ import org.octopusden.octopus.vcsfacade.config.VcsProperties
 import org.octopusden.octopus.vcsfacade.dto.HashOrRefOrDate
 import org.octopusden.octopus.vcsfacade.service.VcsService
 import org.slf4j.LoggerFactory
+import java.util.Date
 
 class BitbucketService(
-    vcsServiceProperties: VcsProperties.Service
+    vcsServiceProperties: VcsProperties.Service,
 ) : VcsService(vcsServiceProperties) {
     private val client: BitbucketClient = BitbucketClassicClient(object : BitbucketClientParametersProvider {
         override fun getApiUrl(): String = httpUrl
+
         override fun getAuth() = vcsServiceProperties.getCredentialProvider() as BitbucketCredentialProvider
     })
 
     override fun getRepositories(): Sequence<Repository> {
         log.trace("=> getRepositories()")
-        return client.getRepositories().asSequence().map { it.toRepository() }
+        return client
+            .getRepositories()
+            .asSequence()
+            .map { it.toRepository() }
             .also { if (log.isTraceEnabled) log.trace("<= getRepositories(): {}", it.toList()) }
     }
 
-    override fun findRepository(group: String, repository: String): Repository? {
+    override fun findRepository(
+        group: String,
+        repository: String,
+    ): Repository? {
         log.trace("=> findRepository({}, {})", group, repository)
         return try {
             client.getRepository(group, repository).toRepository()
@@ -64,37 +71,65 @@ class BitbucketService(
         }.also { log.trace("<= findRepository({}, {}): {}", group, repository, it) }
     }
 
-    override fun getBranches(group: String, repository: String): Sequence<Branch> {
+    override fun getBranches(
+        group: String,
+        repository: String,
+    ): Sequence<Branch> {
         log.trace("=> getBranches({}, {})", group, repository)
-        return client.getBranches(group, repository).asSequence().map {
-            it.toBranch(group, repository)
-        }.also { if (log.isTraceEnabled) log.trace("<= getBranches({}, {}): {}", group, repository, it.toList()) }
+        return client
+            .getBranches(group, repository)
+            .asSequence()
+            .map {
+                it.toBranch(group, repository)
+            }.also { if (log.isTraceEnabled) log.trace("<= getBranches({}, {}): {}", group, repository, it.toList()) }
     }
 
-    override fun getTags(group: String, repository: String): Sequence<Tag> {
+    override fun getTags(
+        group: String,
+        repository: String,
+    ): Sequence<Tag> {
         log.trace("=> getTags({}, {})", group, repository)
-        return client.getTags(group, repository).asSequence().map {
-            it.toTag(group, repository)
-        }.also { if (log.isTraceEnabled) log.trace("<= getTags({}, {}): {}", group, repository, it.toList()) }
+        return client
+            .getTags(group, repository)
+            .asSequence()
+            .map {
+                it.toTag(group, repository)
+            }.also { if (log.isTraceEnabled) log.trace("<= getTags({}, {}): {}", group, repository, it.toList()) }
     }
 
-    override fun createTag(group: String, repository: String, createTag: CreateTag): Tag {
+    override fun createTag(
+        group: String,
+        repository: String,
+        createTag: CreateTag,
+    ): Tag {
         log.trace("=> createTag({}, {}, {})", group, repository, createTag)
-        return client.createTag(
-            group, repository, BitbucketCreateTag(createTag.name, createTag.hashOrRef, createTag.message)
-        ).toTag(group, repository).also {
-            log.trace("<= createTag({}, {}, {}): {}", group, repository, createTag, it)
-        }
+        return client
+            .createTag(
+                group,
+                repository,
+                BitbucketCreateTag(createTag.name, createTag.hashOrRef, createTag.message),
+            ).toTag(group, repository)
+            .also {
+                log.trace("<= createTag({}, {}, {}): {}", group, repository, createTag, it)
+            }
     }
 
-    override fun getTag(group: String, repository: String, name: String): Tag {
+    override fun getTag(
+        group: String,
+        repository: String,
+        name: String,
+    ): Tag {
         log.trace("=> getTag({}, {}, {})", group, repository, name)
         return client.getTag(group, repository, name).toTag(group, repository).also {
             log.trace("<= getTag({}, {}, {}): {}", group, repository, name, it)
         }
     }
 
-    override fun deleteTag(group: String, repository: String, name: String) {
+    override fun deleteTag(
+        group: String,
+        repository: String,
+        name: String,
+    ) {
         log.trace("=> deleteTag({}, {}, {})", group, repository, name)
         client.deleteTag(group, repository, name)
         log.trace("<= deleteTag({}, {}, {})", group, repository, name)
@@ -104,7 +139,7 @@ class BitbucketService(
         group: String,
         repository: String,
         from: HashOrRefOrDate<String, Date>?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ): Sequence<Commit> {
         log.trace("=> getCommits({}, {}, {}, {})", group, repository, from, toHashOrRef)
         val commits = if (from is HashOrRefOrDate.HashOrRefValue) {
@@ -113,14 +148,16 @@ class BitbucketService(
             client.getCommits(group, repository, toHashOrRef, (from as? HashOrRefOrDate.DateValue)?.value)
         }
         return commits.asSequence().map { it.toCommit(group, repository) }.also {
-            if (log.isTraceEnabled) log.trace(
-                "<= getCommits({}, {}, {}, {}): {}",
-                group,
-                repository,
-                from,
-                toHashOrRef,
-                it.toList()
-            )
+            if (log.isTraceEnabled) {
+                log.trace(
+                    "<= getCommits({}, {}, {}, {}): {}",
+                    group,
+                    repository,
+                    from,
+                    toHashOrRef,
+                    it.toList(),
+                )
+            }
         }
     }
 
@@ -128,32 +165,43 @@ class BitbucketService(
         group: String,
         repository: String,
         from: HashOrRefOrDate<String, Date>?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ): Sequence<CommitWithFiles> {
         log.trace("=> getCommitsWithFiles({}, {}, {}, {})", group, repository, from, toHashOrRef)
-        return getCommits(group, repository, from, toHashOrRef).map {
-            val fileChanges = getCommitChanges(group, repository, it)
-            CommitWithFiles(it, fileChanges.size, fileChanges)
-        }.also {
-            if (log.isTraceEnabled) log.trace(
-                "<= getCommitsWithFiles({}, {}, {}, {}): {}",
-                group,
-                repository,
-                from,
-                toHashOrRef,
-                it.toList()
-            )
-        }
+        return getCommits(group, repository, from, toHashOrRef)
+            .map {
+                val fileChanges = getCommitChanges(group, repository, it)
+                CommitWithFiles(it, fileChanges.size, fileChanges)
+            }.also {
+                if (log.isTraceEnabled) {
+                    log.trace(
+                        "<= getCommitsWithFiles({}, {}, {}, {}): {}",
+                        group,
+                        repository,
+                        from,
+                        toHashOrRef,
+                        it.toList(),
+                    )
+                }
+            }
     }
 
-    override fun getCommit(group: String, repository: String, hashOrRef: String): Commit {
+    override fun getCommit(
+        group: String,
+        repository: String,
+        hashOrRef: String,
+    ): Commit {
         log.trace("=> getCommit({}, {}, {})", group, repository, hashOrRef)
         return client.getCommit(group, repository, hashOrRef).toCommit(group, repository).also {
             log.trace("<= getCommit({}, {}, {}): {}", group, repository, hashOrRef, it)
         }
     }
 
-    override fun getCommitWithFiles(group: String, repository: String, hashOrRef: String): CommitWithFiles {
+    override fun getCommitWithFiles(
+        group: String,
+        repository: String,
+        hashOrRef: String,
+    ): CommitWithFiles {
         log.trace("=> getCommitWithFiles({}, {}, {})", group, repository, hashOrRef)
         return with(getCommit(group, repository, hashOrRef)) {
             val fileChanges = getCommitChanges(group, repository, this)
@@ -161,80 +209,114 @@ class BitbucketService(
         }.also { log.trace("<= getCommitWithFiles({}, {}, {}): {}", group, repository, hashOrRef, it) }
     }
 
-    override fun getBranchesCommitGraph(group: String, repository: String): Sequence<CommitWithFiles> {
+    override fun getBranchesCommitGraph(
+        group: String,
+        repository: String,
+    ): Sequence<CommitWithFiles> {
         TODO("Indexing of BitBucket repositories is not supported yet")
     }
 
-    override fun getPullRequests(group: String, repository: String): Sequence<PullRequest> {
+    override fun getPullRequests(
+        group: String,
+        repository: String,
+    ): Sequence<PullRequest> {
         TODO("Indexing of BitBucket repositories is not supported yet")
     }
 
     override fun createPullRequest(
-        group: String, repository: String, createPullRequest: CreatePullRequest
+        group: String,
+        repository: String,
+        createPullRequest: CreatePullRequest,
     ): PullRequest {
         log.trace("=> createPullRequest({}, {}, {})", group, repository, createPullRequest)
-        return client.createPullRequestWithDefaultReviewers(
-            group,
-            repository,
-            createPullRequest.sourceBranch,
-            createPullRequest.targetBranch,
-            createPullRequest.title,
-            createPullRequest.description
-        ).toPullRequest(group, repository).also {
-            log.trace("<= createPullRequest({}, {}, {}): {}", group, repository, createPullRequest, it)
-        }
+        return client
+            .createPullRequestWithDefaultReviewers(
+                group,
+                repository,
+                createPullRequest.sourceBranch,
+                createPullRequest.targetBranch,
+                createPullRequest.title,
+                createPullRequest.description,
+            ).toPullRequest(group, repository)
+            .also {
+                log.trace("<= createPullRequest({}, {}, {}): {}", group, repository, createPullRequest, it)
+            }
     }
 
-    override fun getPullRequest(group: String, repository: String, index: Long): PullRequest {
+    override fun getPullRequest(
+        group: String,
+        repository: String,
+        index: Long,
+    ): PullRequest {
         log.trace("=> getPullRequest({}, {}, {})", group, repository, index)
         return client.getPullRequest(group, repository, index).toPullRequest(group, repository).also {
             log.trace("<= getPullRequest({}, {}, {}): {}", group, repository, index, it)
         }
     }
 
-    override fun findTags(group: String, repository: String, names: Set<String>): Sequence<Tag> {
+    override fun findTags(
+        group: String,
+        repository: String,
+        names: Set<String>,
+    ): Sequence<Tag> {
         log.trace("=> findTags({}, {}, {})", group, repository, names)
-        return names.mapNotNull {
-            try {
-                client.getTag(group, repository, it).toTag(group, repository)
-            } catch (e: NotFoundException) {
-                null
+        return names
+            .mapNotNull {
+                try {
+                    client.getTag(group, repository, it).toTag(group, repository)
+                } catch (e: NotFoundException) {
+                    null
+                }
+            }.asSequence()
+            .also {
+                if (log.isTraceEnabled) log.trace("<= findTags({}, {}, {}): {}", group, repository, names, it.toList())
             }
-        }.asSequence().also {
-            if (log.isTraceEnabled) log.trace("<= findTags({}, {}, {}): {}", group, repository, names, it.toList())
-        }
     }
 
-    override fun findCommits(group: String, repository: String, hashes: Set<String>): Sequence<Commit> {
+    override fun findCommits(
+        group: String,
+        repository: String,
+        hashes: Set<String>,
+    ): Sequence<Commit> {
         log.trace("=> findCommits({}, {}, {})", group, repository, hashes)
-        return hashes.mapNotNull {
-            try {
-                client.getCommit(group, repository, it).toCommit(group, repository)
-            } catch (e: NotFoundException) {
-                null
+        return hashes
+            .mapNotNull {
+                try {
+                    client.getCommit(group, repository, it).toCommit(group, repository)
+                } catch (e: NotFoundException) {
+                    null
+                }
+            }.asSequence()
+            .also {
+                if (log.isTraceEnabled) log.trace("<= findCommits({}, {}, {}): {}", group, repository, hashes, it.toList())
             }
-        }.asSequence().also {
-            if (log.isTraceEnabled) log.trace("<= findCommits({}, {}, {}): {}", group, repository, hashes, it.toList())
-        }
     }
 
-    override fun findPullRequests(group: String, repository: String, indexes: Set<Long>): Sequence<PullRequest> {
+    override fun findPullRequests(
+        group: String,
+        repository: String,
+        indexes: Set<Long>,
+    ): Sequence<PullRequest> {
         log.trace("=> findPullRequests({}, {}, {})", group, repository, indexes)
-        return indexes.mapNotNull {
-            try {
-                client.getPullRequest(group, repository, it).toPullRequest(group, repository)
-            } catch (e: NotFoundException) {
-                null
+        return indexes
+            .mapNotNull {
+                try {
+                    client.getPullRequest(group, repository, it).toPullRequest(group, repository)
+                } catch (e: NotFoundException) {
+                    null
+                }
+            }.asSequence()
+            .also {
+                if (log.isTraceEnabled) {
+                    log.trace(
+                        "<= findPullRequests({}, {}, {}): {}",
+                        group,
+                        repository,
+                        indexes,
+                        it.toList(),
+                    )
+                }
             }
-        }.asSequence().also {
-            if (log.isTraceEnabled) log.trace(
-                "<= findPullRequests({}, {}, {}): {}",
-                group,
-                repository,
-                indexes,
-                it.toList()
-            )
-        }
     }
 
     override fun findBranches(issueKey: String): Sequence<Branch> {
@@ -244,20 +326,31 @@ class BitbucketService(
 
     override fun findCommits(issueKey: String): Sequence<Commit> {
         log.trace("=> findCommits({})", issueKey)
-        return client.getCommits(issueKey).asSequence().map {
-            it.toCommit.toCommit(it.repository.project.key.lowercase(), it.repository.slug.lowercase())
-        }.also { if (log.isTraceEnabled) log.trace("<= findCommits({}): {}", issueKey, it.toList()) }
+        return client
+            .getCommits(issueKey)
+            .asSequence()
+            .map {
+                it.toCommit.toCommit(
+                    it.repository.project.key
+                        .lowercase(),
+                    it.repository.slug.lowercase(),
+                )
+            }.also { if (log.isTraceEnabled) log.trace("<= findCommits({}): {}", issueKey, it.toList()) }
     }
 
     override fun findCommitsWithFiles(issueKey: String): Sequence<CommitWithFiles> {
         log.trace("=> findCommitsWithFiles({})", issueKey)
-        return client.getCommits(issueKey).asSequence().map {
-            val group = it.repository.project.key.lowercase()
-            val repository = it.repository.slug.lowercase()
-            val commit = it.toCommit.toCommit(group, repository)
-            val fileChanges = getCommitChanges(group, repository, commit)
-            CommitWithFiles(commit, fileChanges.size, fileChanges)
-        }.also { if (log.isTraceEnabled) log.trace("<= findCommitsWithFiles({}): {}", issueKey, it.toList()) }
+        return client
+            .getCommits(issueKey)
+            .asSequence()
+            .map {
+                val group = it.repository.project.key
+                    .lowercase()
+                val repository = it.repository.slug.lowercase()
+                val commit = it.toCommit.toCommit(group, repository)
+                val fileChanges = getCommitChanges(group, repository, commit)
+                CommitWithFiles(commit, fileChanges.size, fileChanges)
+            }.also { if (log.isTraceEnabled) log.trace("<= findCommitsWithFiles({}): {}", issueKey, it.toList()) }
     }
 
     override fun findPullRequests(issueKey: String): Sequence<PullRequest> {
@@ -265,87 +358,108 @@ class BitbucketService(
         return emptySequence()
     }
 
-    private fun getCommitChanges(group: String, repository: String, commit: Commit): List<FileChange> {
+    private fun getCommitChanges(
+        group: String,
+        repository: String,
+        commit: Commit,
+    ): List<FileChange> {
         log.trace("=> getCommitChanges({}, {}, {})", group, repository, commit)
-        return client.getCommitChanges(group, repository, commit.hash).flatMap {
-            val files = mutableListOf(
-                FileChange(
-                    when (it.type) {
-                        BitbucketCommitChange.BitbucketCommitChangeType.ADD,
-                        BitbucketCommitChange.BitbucketCommitChangeType.COPY,
-                        BitbucketCommitChange.BitbucketCommitChangeType.MOVE -> FileChangeType.ADD
+        return client
+            .getCommitChanges(group, repository, commit.hash)
+            .flatMap {
+                val files = mutableListOf(
+                    FileChange(
+                        when (it.type) {
+                            BitbucketCommitChange.BitbucketCommitChangeType.ADD,
+                            BitbucketCommitChange.BitbucketCommitChangeType.COPY,
+                            BitbucketCommitChange.BitbucketCommitChangeType.MOVE,
+                            -> FileChangeType.ADD
 
-                        BitbucketCommitChange.BitbucketCommitChangeType.MODIFY -> FileChangeType.MODIFY
+                            BitbucketCommitChange.BitbucketCommitChangeType.MODIFY -> FileChangeType.MODIFY
 
-                        BitbucketCommitChange.BitbucketCommitChangeType.DELETE -> FileChangeType.DELETE
-                    },
-                    it.path.value,
-                    "${commit.link}#${it.path.value}"
+                            BitbucketCommitChange.BitbucketCommitChangeType.DELETE -> FileChangeType.DELETE
+                        },
+                        it.path.value,
+                        "${commit.link}#${it.path.value}",
+                    ),
                 )
-            )
-            if (it.type == BitbucketCommitChange.BitbucketCommitChangeType.MOVE) {
-                files.add(FileChange(FileChangeType.DELETE, it.srcPath!!.value, "${commit.link}#${it.srcPath!!.value}"))
-            }
-            files
-        }.also { log.trace("<= getCommitChanges({}, {}, {}): {}", group, repository, commit, it) }
+                if (it.type == BitbucketCommitChange.BitbucketCommitChangeType.MOVE) {
+                    files.add(FileChange(FileChangeType.DELETE, it.srcPath!!.value, "${commit.link}#${it.srcPath!!.value}"))
+                }
+                files
+            }.also { log.trace("<= getCommitChanges({}, {}, {}): {}", group, repository, commit, it) }
     }
 
-    private fun getRepository(project: String, repository: String) = Repository(
+    private fun getRepository(
+        project: String,
+        repository: String,
+    ) = Repository(
         "$sshUrl/$project/$repository.git",
         "$httpUrl/projects/$project/repos/$repository/browse",
-        "$httpUrl/projects/$project/avatar.png?s=48"
+        "$httpUrl/projects/$project/avatar.png?s=48",
     )
 
     private fun BitbucketRepository.toRepository() = getRepository(project.key.lowercase(), slug.lowercase())
 
-    private fun BitbucketBranch.toBranch(project: String, repository: String) = Branch(
+    private fun BitbucketBranch.toBranch(
+        project: String,
+        repository: String,
+    ) = Branch(
         displayId,
         latestCommit,
         "$httpUrl/projects/$project/repos/$repository/browse?at=$displayId",
-        getRepository(project, repository)
+        getRepository(project, repository),
     )
 
-    private fun BitbucketTag.toTag(project: String, repository: String) = Tag(
+    private fun BitbucketTag.toTag(
+        project: String,
+        repository: String,
+    ) = Tag(
         displayId,
         latestCommit,
         "$httpUrl/projects/$project/repos/$repository/browse?at=$displayId",
-        getRepository(project, repository)
+        getRepository(project, repository),
     )
 
     private fun BitbucketUser.toUser() = User(name, "$httpUrl/users/$name/avatar.png?s=48")
 
-    private fun BitbucketCommit.toCommit(project: String, repository: String) = Commit(
+    private fun BitbucketCommit.toCommit(
+        project: String,
+        repository: String,
+    ) = Commit(
         id,
         message,
         authorTimestamp,
         author.toUser(),
         parents.map { it.id },
         "$httpUrl/projects/$project/repos/$repository/commits/$id",
-        getRepository(project, repository)
+        getRepository(project, repository),
     )
 
-    private fun BitbucketPullRequest.toPullRequest(project: String, repository: String) =
-        author.user.toUser().let { author ->
-            PullRequest(
-                id,
-                title,
-                description ?: "",
-                author,
-                fromRef.displayId,
-                toRef.displayId,
-                emptyList(),
-                reviewers.map { PullRequestReviewer(it.user.toUser(), it.approved) },
-                when (state) {
-                    BitbucketPullRequestState.MERGED -> PullRequestStatus.MERGED
-                    BitbucketPullRequestState.DECLINED -> PullRequestStatus.DECLINED
-                    BitbucketPullRequestState.OPEN -> PullRequestStatus.OPEN
-                },
-                createdDate,
-                updatedDate,
-                "$httpUrl/projects/$project/repos/$repository/pull-requests/$id/overview",
-                getRepository(project, repository)
-            )
-        }
+    private fun BitbucketPullRequest.toPullRequest(
+        project: String,
+        repository: String,
+    ) = author.user.toUser().let { author ->
+        PullRequest(
+            id,
+            title,
+            description ?: "",
+            author,
+            fromRef.displayId,
+            toRef.displayId,
+            emptyList(),
+            reviewers.map { PullRequestReviewer(it.user.toUser(), it.approved) },
+            when (state) {
+                BitbucketPullRequestState.MERGED -> PullRequestStatus.MERGED
+                BitbucketPullRequestState.DECLINED -> PullRequestStatus.DECLINED
+                BitbucketPullRequestState.OPEN -> PullRequestStatus.OPEN
+            },
+            createdDate,
+            updatedDate,
+            "$httpUrl/projects/$project/repos/$repository/pull-requests/$id/overview",
+            getRepository(project, repository),
+        )
+    }
 
     companion object {
         private val log = LoggerFactory.getLogger(BitbucketService::class.java)

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/GiteaService.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/GiteaService.kt
@@ -1,8 +1,5 @@
 package org.octopusden.octopus.vcsfacade.service.impl
 
-import java.math.BigInteger
-import java.security.MessageDigest
-import java.util.Date
 import org.octopusden.octopus.infrastructure.client.commons.ClientParametersProvider
 import org.octopusden.octopus.infrastructure.gitea.client.GiteaClassicClient
 import org.octopusden.octopus.infrastructure.gitea.client.GiteaClient
@@ -44,26 +41,38 @@ import org.octopusden.octopus.vcsfacade.dto.HashOrRefOrDate.DateValue
 import org.octopusden.octopus.vcsfacade.dto.HashOrRefOrDate.HashOrRefValue
 import org.octopusden.octopus.vcsfacade.service.VcsService
 import org.slf4j.LoggerFactory
+import java.math.BigInteger
+import java.security.MessageDigest
+import java.util.Date
 
 class GiteaService(
-    vcsServiceProperties: VcsProperties.Service
+    vcsServiceProperties: VcsProperties.Service,
 ) : VcsService(vcsServiceProperties) {
     private val client: GiteaClient = GiteaClassicClient(object : ClientParametersProvider {
         override fun getApiUrl() = httpUrl
+
         override fun getAuth() = vcsServiceProperties.getCredentialProvider()
     })
 
     override fun getRepositories(): Sequence<Repository> {
         log.trace("=> getRepositories()")
-        return client.getOrganizations().asSequence().flatMap { client.getRepositories(it.name) }
+        return client
+            .getOrganizations()
+            .asSequence()
+            .flatMap { client.getRepositories(it.name) }
             .map { toRepository(it) }
             .also { if (log.isTraceEnabled) log.trace("<= getRepositories(): {}", it.toList()) }
     }
 
-    private fun getRepository(group: String, repository: String) =
-        toRepository(client.getRepository(group, repository))
+    private fun getRepository(
+        group: String,
+        repository: String,
+    ) = toRepository(client.getRepository(group, repository))
 
-    override fun findRepository(group: String, repository: String): Repository? {
+    override fun findRepository(
+        group: String,
+        repository: String,
+    ): Repository? {
         log.trace("=> findRepository({}, {})", group, repository)
         return try {
             getRepository(group, repository)
@@ -72,44 +81,68 @@ class GiteaService(
         }.also { log.trace("<= findRepository({}, {}): {}", group, repository, it) }
     }
 
-    override fun getBranches(group: String, repository: String): Sequence<Branch> {
+    override fun getBranches(
+        group: String,
+        repository: String,
+    ): Sequence<Branch> {
         log.trace("=> getBranches({}, {})", group, repository)
         return with(getRepository(group, repository)) {
             client.getBranches(group, repository).asSequence().map { it.toBranch(this) }
         }.also { if (log.isTraceEnabled) log.trace("<= getBranches({}, {}): {}", group, repository, it.toList()) }
     }
 
-    override fun getTags(group: String, repository: String): Sequence<Tag> {
+    override fun getTags(
+        group: String,
+        repository: String,
+    ): Sequence<Tag> {
         log.trace("=> getTags({}, {})", group, repository)
         return with(getRepository(group, repository)) {
             client.getTags(group, repository).asSequence().map { it.toTag(this) }
         }.also { if (log.isTraceEnabled) log.trace("<= getTags({}, {}): {}", group, repository, it.toList()) }
     }
 
-    override fun createTag(group: String, repository: String, createTag: CreateTag): Tag {
+    override fun createTag(
+        group: String,
+        repository: String,
+        createTag: CreateTag,
+    ): Tag {
         log.trace("=> createTag({}, {}, {})", group, repository, createTag)
         return with(getRepository(group, repository)) {
-            client.createTag(
-                group, repository, GiteaCreateTag(createTag.name, createTag.hashOrRef, createTag.message)
-            ).toTag(this)
+            client
+                .createTag(
+                    group,
+                    repository,
+                    GiteaCreateTag(createTag.name, createTag.hashOrRef, createTag.message),
+                ).toTag(this)
         }.also { log.trace("<= createTag({}, {}, {}): {}", group, repository, createTag, it) }
     }
 
-    override fun getTag(group: String, repository: String, name: String): Tag {
+    override fun getTag(
+        group: String,
+        repository: String,
+        name: String,
+    ): Tag {
         log.trace("=> getTag({}, {}, {})", group, repository, name)
         return with(getRepository(group, repository)) {
             client.getTag(group, repository, name).toTag(this)
         }.also { log.trace("<= getTag({}, {}, {}): {}", group, repository, name, it) }
     }
 
-    override fun deleteTag(group: String, repository: String, name: String) {
+    override fun deleteTag(
+        group: String,
+        repository: String,
+        name: String,
+    ) {
         log.trace("=> deleteTag({}, {}, {})", group, repository, name)
         client.deleteTag(group, repository, name)
         log.trace("<= deleteTag({}, {}, {})", group, repository, name)
     }
 
     override fun getCommits(
-        group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String
+        group: String,
+        repository: String,
+        from: HashOrRefOrDate<String, Date>?,
+        toHashOrRef: String,
     ): Sequence<Commit> {
         log.trace("=> getCommits({}, {}, {}, {})", group, repository, from, toHashOrRef)
         return with(getRepository(group, repository)) {
@@ -120,19 +153,24 @@ class GiteaService(
             }
             commits.asSequence().map { it.toCommit(this) }
         }.also {
-            if (log.isTraceEnabled) log.trace(
-                "<= getCommits({}, {}, {}, {}): {}",
-                group,
-                repository,
-                from,
-                toHashOrRef,
-                it.toList()
-            )
+            if (log.isTraceEnabled) {
+                log.trace(
+                    "<= getCommits({}, {}, {}, {}): {}",
+                    group,
+                    repository,
+                    from,
+                    toHashOrRef,
+                    it.toList(),
+                )
+            }
         }
     }
 
     override fun getCommitsWithFiles(
-        group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String
+        group: String,
+        repository: String,
+        from: HashOrRefOrDate<String, Date>?,
+        toHashOrRef: String,
     ): Sequence<CommitWithFiles> {
         log.trace("=> getCommitsWithFiles({}, {}, {}, {})", group, repository, from, toHashOrRef)
         return with(getRepository(group, repository)) {
@@ -143,56 +181,83 @@ class GiteaService(
             }
             commits.asSequence().map { it.toCommitWithFiles(this) }
         }.also {
-            if (log.isTraceEnabled) log.trace(
-                "<= getCommitsWithFiles({}, {}, {}, {}): {}",
-                group,
-                repository,
-                from,
-                toHashOrRef,
-                it.toList()
-            )
+            if (log.isTraceEnabled) {
+                log.trace(
+                    "<= getCommitsWithFiles({}, {}, {}, {}): {}",
+                    group,
+                    repository,
+                    from,
+                    toHashOrRef,
+                    it.toList(),
+                )
+            }
         }
     }
 
-    override fun getBranchesCommitGraph(group: String, repository: String): Sequence<CommitWithFiles> {
+    override fun getBranchesCommitGraph(
+        group: String,
+        repository: String,
+    ): Sequence<CommitWithFiles> {
         log.trace("=> getBranchesCommitGraph({}, {})", group, repository)
         return with(getRepository(group, repository)) {
             client.getBranchesCommitGraph(group, repository, true).map { it.toCommitWithFiles(this) }
         }.also {
-            if (log.isTraceEnabled) log.trace(
-                "<= getBranchesCommitGraph({}, {}): {}",
-                group,
-                repository,
-                it.toList()
-            )
+            if (log.isTraceEnabled) {
+                log.trace(
+                    "<= getBranchesCommitGraph({}, {}): {}",
+                    group,
+                    repository,
+                    it.toList(),
+                )
+            }
         }
     }
 
-    override fun getCommit(group: String, repository: String, hashOrRef: String): Commit {
+    override fun getCommit(
+        group: String,
+        repository: String,
+        hashOrRef: String,
+    ): Commit {
         log.trace("=> getCommit({}, {}, {})", group, repository, hashOrRef)
-        return client.getCommit(group, repository, hashOrRef).toCommit(getRepository(group, repository))
+        return client
+            .getCommit(group, repository, hashOrRef)
+            .toCommit(getRepository(group, repository))
             .also { log.trace("<= getCommit({}, {}, {}): {}", group, repository, hashOrRef, it) }
     }
 
-    override fun getCommitWithFiles(group: String, repository: String, hashOrRef: String): CommitWithFiles {
+    override fun getCommitWithFiles(
+        group: String,
+        repository: String,
+        hashOrRef: String,
+    ): CommitWithFiles {
         log.trace("=> getCommitWithFiles({}, {}, {})", group, repository, hashOrRef)
-        return client.getCommit(group, repository, hashOrRef, true).toCommitWithFiles(getRepository(group, repository))
+        return client
+            .getCommit(group, repository, hashOrRef, true)
+            .toCommitWithFiles(getRepository(group, repository))
             .also { log.trace("<= getCommitWithFiles({}, {}, {}): {}", group, repository, hashOrRef, it) }
     }
 
-    fun getPullRequestReviews(group: String, repository: String, number: Long): List<GiteaPullRequestReview> {
+    fun getPullRequestReviews(
+        group: String,
+        repository: String,
+        number: Long,
+    ): List<GiteaPullRequestReview> {
         log.trace("=> getPullRequestReviews({}, {}, {})", group, repository, number)
-        return client.getPullRequestReviews(group, repository, number)
+        return client
+            .getPullRequestReviews(group, repository, number)
             .also { log.trace("<= getPullRequestReviews({}, {}, {}): {}", group, repository, number, it) }
     }
 
-    override fun getPullRequests(group: String, repository: String): Sequence<PullRequest> {
+    override fun getPullRequests(
+        group: String,
+        repository: String,
+    ): Sequence<PullRequest> {
         log.trace("=> getPullRequests({}, {})", group, repository)
         return with(getRepository(group, repository)) {
             try {
                 client.getPullRequests(group, repository)
             } catch (e: NotFoundException) {
-                emptyList() //for some reason Gitea returns 404 in case of empty repository
+                emptyList() // for some reason Gitea returns 404 in case of empty repository
             }.asSequence().map {
                 it.toPullRequest(this, getPullRequestReviews(group, repository, it.number))
             }
@@ -200,81 +265,110 @@ class GiteaService(
     }
 
     override fun createPullRequest(
-        group: String, repository: String, createPullRequest: CreatePullRequest
+        group: String,
+        repository: String,
+        createPullRequest: CreatePullRequest,
     ): PullRequest {
         log.trace("=> getPullRequests({}, {}, {})", group, repository, createPullRequest)
-        return client.createPullRequestWithDefaultReviewers(
-            group,
-            repository,
-            createPullRequest.sourceBranch,
-            createPullRequest.targetBranch,
-            createPullRequest.title,
-            createPullRequest.description
-        ).let {
-            it.toPullRequest(
-                getRepository(group, repository), client.getPullRequestReviews(group, repository, it.number)
-            )
-        }.also { log.trace("<= getPullRequests({}, {}, {}): {}", group, repository, createPullRequest, it) }
+        return client
+            .createPullRequestWithDefaultReviewers(
+                group,
+                repository,
+                createPullRequest.sourceBranch,
+                createPullRequest.targetBranch,
+                createPullRequest.title,
+                createPullRequest.description,
+            ).let {
+                it.toPullRequest(
+                    getRepository(group, repository),
+                    client.getPullRequestReviews(group, repository, it.number),
+                )
+            }.also { log.trace("<= getPullRequests({}, {}, {}): {}", group, repository, createPullRequest, it) }
     }
 
-    override fun getPullRequest(group: String, repository: String, index: Long): PullRequest {
+    override fun getPullRequest(
+        group: String,
+        repository: String,
+        index: Long,
+    ): PullRequest {
         log.trace("=> getPullRequest({}, {}, {})", group, repository, index)
-        return client.getPullRequest(group, repository, index).let {
-            it.toPullRequest(
-                getRepository(group, repository), client.getPullRequestReviews(group, repository, it.number)
-            )
-        }.also { log.trace("<= getPullRequest({}, {}, {}): {}", group, repository, index, it) }
+        return client
+            .getPullRequest(group, repository, index)
+            .let {
+                it.toPullRequest(
+                    getRepository(group, repository),
+                    client.getPullRequestReviews(group, repository, it.number),
+                )
+            }.also { log.trace("<= getPullRequest({}, {}, {}): {}", group, repository, index, it) }
     }
 
-    override fun findTags(group: String, repository: String, names: Set<String>): Sequence<Tag> {
+    override fun findTags(
+        group: String,
+        repository: String,
+        names: Set<String>,
+    ): Sequence<Tag> {
         log.trace("=> findTags({}, {}, {})", group, repository, names)
         return with(getRepository(group, repository)) {
-            names.mapNotNull {
-                try {
-                    client.getTag(group, repository, it).toTag(this)
-                } catch (e: NotFoundException) {
-                    null
-                }
-            }.asSequence()
+            names
+                .mapNotNull {
+                    try {
+                        client.getTag(group, repository, it).toTag(this)
+                    } catch (e: NotFoundException) {
+                        null
+                    }
+                }.asSequence()
         }.also {
             if (log.isTraceEnabled) log.trace("<= findTags({}, {}, {}): {}", group, repository, names, it.toList())
         }
     }
 
-    override fun findCommits(group: String, repository: String, hashes: Set<String>): Sequence<Commit> {
+    override fun findCommits(
+        group: String,
+        repository: String,
+        hashes: Set<String>,
+    ): Sequence<Commit> {
         log.trace("=> findCommits({}, {}, {})", group, repository, hashes)
         return with(getRepository(group, repository)) {
-            hashes.mapNotNull {
-                try {
-                    client.getCommit(group, repository, it).toCommit(this)
-                } catch (e: NotFoundException) {
-                    null
-                }
-            }.asSequence()
+            hashes
+                .mapNotNull {
+                    try {
+                        client.getCommit(group, repository, it).toCommit(this)
+                    } catch (e: NotFoundException) {
+                        null
+                    }
+                }.asSequence()
         }.also {
             if (log.isTraceEnabled) log.trace("<= findCommits({}, {}, {}): {}", group, repository, hashes, it.toList())
         }
     }
 
-    override fun findPullRequests(group: String, repository: String, indexes: Set<Long>): Sequence<PullRequest> {
+    override fun findPullRequests(
+        group: String,
+        repository: String,
+        indexes: Set<Long>,
+    ): Sequence<PullRequest> {
         log.trace("=> findPullRequests({}, {}, {})", group, repository, indexes)
         return with(getRepository(group, repository)) {
-            indexes.mapNotNull {
-                try {
-                    client.getPullRequest(group, repository, it)
-                        .toPullRequest(this, client.getPullRequestReviews(group, repository, it))
-                } catch (e: NotFoundException) {
-                    null
-                }
-            }.asSequence()
+            indexes
+                .mapNotNull {
+                    try {
+                        client
+                            .getPullRequest(group, repository, it)
+                            .toPullRequest(this, client.getPullRequestReviews(group, repository, it))
+                    } catch (e: NotFoundException) {
+                        null
+                    }
+                }.asSequence()
         }.also {
-            if (log.isTraceEnabled) log.trace(
-                "<= findPullRequests({}, {}, {}): {}",
-                group,
-                repository,
-                indexes,
-                it.toList()
-            )
+            if (log.isTraceEnabled) {
+                log.trace(
+                    "<= findPullRequests({}, {}, {}): {}",
+                    group,
+                    repository,
+                    indexes,
+                    it.toList(),
+                )
+            }
         }
     }
 
@@ -301,57 +395,75 @@ class GiteaService(
     fun toRepository(giteaRepository: GiteaRepository): Repository {
         val repository = giteaRepository.name.lowercase()
         val organization = giteaRepository.fullName.lowercase().removeSuffix("/$repository")
-        return Repository("$sshUrl/$organization/$repository.git", //TODO: add "useColon" parameter?
+        return Repository(
+            "$sshUrl/$organization/$repository.git", // TODO: add "useColon" parameter?
             "$httpUrl/$organization/$repository",
-            giteaRepository.avatarUrl.ifBlank { null }
+            giteaRepository.avatarUrl.ifBlank { null },
         )
     }
 
     companion object {
         private val log = LoggerFactory.getLogger(GiteaService::class.java)
 
-        fun GiteaBranch.toBranch(repository: Repository) = Branch(
-            name, commit.id, "${repository.link}/src/branch/$name", repository
-        )
+        fun GiteaBranch.toBranch(repository: Repository) =
+            Branch(
+                name,
+                commit.id,
+                "${repository.link}/src/branch/$name",
+                repository,
+            )
 
-        fun GiteaTag.toTag(repository: Repository) = Tag(
-            name, commit.sha, "${repository.link}/src/tag/$name", repository
-        )
+        fun GiteaTag.toTag(repository: Repository) =
+            Tag(
+                name,
+                commit.sha,
+                "${repository.link}/src/tag/$name",
+                repository,
+            )
 
         private fun GiteaUser.toUser() = User(username, avatarUrl.ifBlank { null })
 
-        private fun GiteaCommit.toCommit(repository: Repository) = Commit(
-            sha,
-            commit.message,
-            created,
-            author?.toUser() ?: User(commit.author.name),
-            parents.map { it.sha },
-            "${repository.link}/commit/$sha",
-            repository
-        )
+        private fun GiteaCommit.toCommit(repository: Repository) =
+            Commit(
+                sha,
+                commit.message,
+                created,
+                author?.toUser() ?: User(commit.author.name),
+                parents.map { it.sha },
+                "${repository.link}/commit/$sha",
+                repository,
+            )
 
-        private fun String.sha1() = BigInteger(1, MessageDigest.getInstance("SHA-1").digest(toByteArray()))
-            .toString(16).padStart(32, '0')
+        private fun String.sha1() =
+            BigInteger(1, MessageDigest.getInstance("SHA-1").digest(toByteArray()))
+                .toString(16)
+                .padStart(32, '0')
 
-        private fun GiteaCommit.toCommitWithFiles(repository: Repository) = with(toCommit(repository)) {
-            val fileChanges = files!!.map {
-                FileChange(
-                    when (it.status) {
-                        GiteaCommit.GiteaCommitAffectedFileStatus.ADDED -> FileChangeType.ADD
-                        GiteaCommit.GiteaCommitAffectedFileStatus.MODIFIED -> FileChangeType.MODIFY
-                        GiteaCommit.GiteaCommitAffectedFileStatus.REMOVED -> FileChangeType.DELETE
-                    }, it.filename, "${this.link}#diff-${it.filename.sha1()}"
-                )
+        private fun GiteaCommit.toCommitWithFiles(repository: Repository) =
+            with(toCommit(repository)) {
+                val fileChanges = files!!.map {
+                    FileChange(
+                        when (it.status) {
+                            GiteaCommit.GiteaCommitAffectedFileStatus.ADDED -> FileChangeType.ADD
+                            GiteaCommit.GiteaCommitAffectedFileStatus.MODIFIED -> FileChangeType.MODIFY
+                            GiteaCommit.GiteaCommitAffectedFileStatus.REMOVED -> FileChangeType.DELETE
+                        },
+                        it.filename,
+                        "${this.link}#diff-${it.filename.sha1()}",
+                    )
+                }
+                CommitWithFiles(this, fileChanges.size, fileChanges)
             }
-            CommitWithFiles(this, fileChanges.size, fileChanges)
-        }
 
         fun GiteaPullRequest.toPullRequest(
-            repository: Repository, giteaPullRequestReviews: List<GiteaPullRequestReview>
+            repository: Repository,
+            giteaPullRequestReviews: List<GiteaPullRequestReview>,
         ): PullRequest {
-            val approvedGiteaUserIds = giteaPullRequestReviews.filter {
-                it.state == GiteaPullRequestReview.GiteaPullRequestReviewState.APPROVED && !it.dismissed
-            }.mapNotNull { it.user?.id }.toSet()
+            val approvedGiteaUserIds = giteaPullRequestReviews
+                .filter {
+                    it.state == GiteaPullRequestReview.GiteaPullRequestReviewState.APPROVED && !it.dismissed
+                }.mapNotNull { it.user?.id }
+                .toSet()
             return PullRequest(
                 number,
                 title,
@@ -371,7 +483,7 @@ class GiteaService(
                 createdAt,
                 updatedAt,
                 "${repository.link}/pulls/$number",
-                repository
+                repository,
             )
         }
     }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/IndexerServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/IndexerServiceImpl.kt
@@ -1,7 +1,5 @@
 package org.octopusden.octopus.vcsfacade.service.impl
 
-import java.util.Date
-import java.util.concurrent.Future
 import org.octopusden.octopus.infrastructure.gitea.client.dto.GiteaBranch
 import org.octopusden.octopus.infrastructure.gitea.client.dto.GiteaShortCommit
 import org.octopusden.octopus.infrastructure.gitea.client.dto.GiteaTag
@@ -30,83 +28,114 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.core.task.AsyncTaskExecutor
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import java.util.Date
+import java.util.concurrent.Future
 
 @Service
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 class IndexerServiceImpl(
     private val vcsManager: VcsManager,
     private val openSearchService: OpenSearchService,
     @Qualifier("opensearchIndexScanExecutor") private val opensearchIndexScanExecutor: AsyncTaskExecutor,
-    @Qualifier("isMaster") private val isMaster: Boolean
+    @Qualifier("isMaster") private val isMaster: Boolean,
 ) : IndexerService {
-    private fun getIndexingGiteaService(id: String) = vcsManager.findVcsServiceById(id)?.let {
-        if (it.indexing && it.type == VcsServiceType.GITEA) it as GiteaService
-        else null
-    } ?: throw IllegalStateException("There is no configured Gitea service with id '$id' and enabled indexing")
+    private fun getIndexingGiteaService(id: String) =
+        vcsManager.findVcsServiceById(id)?.let {
+            if (it.indexing && it.type == VcsServiceType.GITEA) {
+                it as GiteaService
+            } else {
+                null
+            }
+        } ?: throw IllegalStateException("There is no configured Gitea service with id '$id' and enabled indexing")
 
-    override fun registerGiteaCreateRefEvent(vcsServiceId: String, createRefEvent: GiteaCreateRefEvent) {
+    override fun registerGiteaCreateRefEvent(
+        vcsServiceId: String,
+        createRefEvent: GiteaCreateRefEvent,
+    ) {
         log.trace("=> registerGiteaCreateRefEvent({}, {})", vcsServiceId, createRefEvent)
         val giteaService = getIndexingGiteaService(vcsServiceId)
         val repositoryDocument = giteaService.toRepository(createRefEvent.repository).toDocument(giteaService)
         checkInRepository(repositoryDocument)
         val refDocument = when (createRefEvent.refType.refType) {
             RefType.BRANCH -> GiteaBranch(
-                createRefEvent.ref, GiteaBranch.PayloadCommit(createRefEvent.sha)
+                createRefEvent.ref,
+                GiteaBranch.PayloadCommit(createRefEvent.sha),
             ).toBranch(repositoryDocument.toDto()).toDocument(repositoryDocument)
 
-            RefType.TAG -> GiteaTag(createRefEvent.ref, GiteaShortCommit(createRefEvent.sha)).toTag(
-                repositoryDocument.toDto()
-            ).toDocument(repositoryDocument)
+            RefType.TAG -> GiteaTag(createRefEvent.ref, GiteaShortCommit(createRefEvent.sha))
+                .toTag(
+                    repositoryDocument.toDto(),
+                ).toDocument(repositoryDocument)
         }
         openSearchService.saveRefs(sequenceOf(refDocument))
         log.trace("<= registerGiteaCreateRefEvent({}, {})", vcsServiceId, createRefEvent)
     }
 
-    override fun registerGiteaDeleteRefEvent(vcsServiceId: String, deleteRefEvent: GiteaDeleteRefEvent) {
+    override fun registerGiteaDeleteRefEvent(
+        vcsServiceId: String,
+        deleteRefEvent: GiteaDeleteRefEvent,
+    ) {
         log.trace("=> registerGiteaDeleteRefEvent({}, {})", vcsServiceId, deleteRefEvent)
         val giteaService = getIndexingGiteaService(vcsServiceId)
         val repositoryDocument = giteaService.toRepository(deleteRefEvent.repository).toDocument(giteaService)
         checkInRepository(repositoryDocument, deleteRefEvent.refType.refType == RefType.BRANCH)
         val refDocumentId = when (deleteRefEvent.refType.refType) {
-            RefType.BRANCH -> GiteaBranch(deleteRefEvent.ref, GiteaBranch.PayloadCommit("unknown")).toBranch(
-                repositoryDocument.toDto()
-            ).toDocument(repositoryDocument)
+            RefType.BRANCH -> GiteaBranch(deleteRefEvent.ref, GiteaBranch.PayloadCommit("unknown"))
+                .toBranch(
+                    repositoryDocument.toDto(),
+                ).toDocument(repositoryDocument)
 
             RefType.TAG -> GiteaTag(
-                deleteRefEvent.ref, GiteaShortCommit("unknown")
+                deleteRefEvent.ref,
+                GiteaShortCommit("unknown"),
             ).toTag(repositoryDocument.toDto()).toDocument(repositoryDocument)
         }.id
         openSearchService.deleteRefsByIds(setOf(refDocumentId))
         log.trace("<= registerGiteaDeleteRefEvent({}, {})", vcsServiceId, deleteRefEvent)
     }
 
-    override fun registerGiteaPushEvent(vcsServiceId: String, pushEvent: GiteaPushEvent) {
+    override fun registerGiteaPushEvent(
+        vcsServiceId: String,
+        pushEvent: GiteaPushEvent,
+    ) {
         log.trace("=> registerGiteaPushEvent({}, {})", vcsServiceId, pushEvent)
         val giteaService = getIndexingGiteaService(vcsServiceId)
         val repositoryDocument = giteaService.toRepository(pushEvent.repository).toDocument(giteaService)
         checkInRepository(repositoryDocument)
-        openSearchService.saveCommits(pushEvent.commits.asSequence().map {
-            //IMPORTANT: commits in push event does not contain all demanded data, so it is required to get it from gitea directly
-            giteaService.getCommitWithFiles(repositoryDocument.group, repositoryDocument.name, it.id)
-                .toDocument(repositoryDocument)
-        })
+        openSearchService.saveCommits(
+            pushEvent.commits.asSequence().map {
+                // IMPORTANT: commits in push event does not contain all demanded data, so it is required to get it from gitea directly
+                giteaService
+                    .getCommitWithFiles(repositoryDocument.group, repositoryDocument.name, it.id)
+                    .toDocument(repositoryDocument)
+            },
+        )
         log.trace("<= registerGiteaPushEvent({}, {})", vcsServiceId, pushEvent)
     }
 
-    override fun registerGiteaPullRequestEvent(vcsServiceId: String, pullRequestEvent: GiteaPullRequestEvent) {
+    override fun registerGiteaPullRequestEvent(
+        vcsServiceId: String,
+        pullRequestEvent: GiteaPullRequestEvent,
+    ) {
         log.trace("=> registerGiteaPullRequestEvent({}, {})", vcsServiceId, pullRequestEvent)
         val giteaService = getIndexingGiteaService(vcsServiceId)
         val repositoryDocument = giteaService.toRepository(pullRequestEvent.repository).toDocument(giteaService)
         checkInRepository(repositoryDocument)
-        val pullRequestDocument = pullRequestEvent.pullRequest.toPullRequest(
-            repositoryDocument.toDto(),
-            //IMPORTANT: to calculate reviewers approves it is required to get pull request reviews from gitea directly
-            giteaService.getPullRequestReviews(
-                repositoryDocument.group, repositoryDocument.name, pullRequestEvent.pullRequest.number
-            )
-        ).toDocument(repositoryDocument)
+        val pullRequestDocument = pullRequestEvent.pullRequest
+            .toPullRequest(
+                repositoryDocument.toDto(),
+                // IMPORTANT: to calculate reviewers approves it is required to get pull request reviews from gitea directly
+                giteaService.getPullRequestReviews(
+                    repositoryDocument.group,
+                    repositoryDocument.name,
+                    pullRequestEvent.pullRequest.number,
+                ),
+            ).toDocument(repositoryDocument)
         openSearchService.savePullRequests(sequenceOf(pullRequestDocument))
         log.trace("<= registerGiteaPullRequestEvent({}, {})", vcsServiceId, pullRequestEvent)
     }
@@ -115,16 +144,18 @@ class IndexerServiceImpl(
         log.trace("=> scheduleRepositoryScan({})", sshUrl)
         checkInRepository(
             Repository(sshUrl.lowercase(), "undefined").toDocument(vcsManager.getVcsServiceForSshUrl(sshUrl)),
-            true
+            true,
         )
         log.trace("<= scheduleRepositoryScan({})", sshUrl)
     }
 
     override fun getIndexReport(scanRequired: Boolean?): IndexReport {
         log.trace("=> getIndexReport({})", scanRequired)
-        return IndexReport(openSearchService.getRepositoriesInfo(scanRequired).map {
-            IndexReport.IndexReportRepository(it.repository.sshUrl, it.scanRequired, it.lastScanAt)
-        }).also { log.trace("=> getIndexReport({}): {}", scanRequired, it) }
+        return IndexReport(
+            openSearchService.getRepositoriesInfo(scanRequired).map {
+                IndexReport.IndexReportRepository(it.repository.sshUrl, it.scanRequired, it.lastScanAt)
+            },
+        ).also { log.trace("=> getIndexReport({}): {}", scanRequired, it) }
     }
 
     private fun Repository.toDocument(vcsService: VcsService): RepositoryDocument {
@@ -132,7 +163,10 @@ class IndexerServiceImpl(
         return RepositoryDocument(vcsService.id, group, repository, sshUrl, link, avatar)
     }
 
-    private fun checkInRepository(repositoryDocument: RepositoryDocument, rescan: Boolean = false) {
+    private fun checkInRepository(
+        repositoryDocument: RepositoryDocument,
+        rescan: Boolean = false,
+    ) {
         openSearchService.findRepositoryInfoById(repositoryDocument.id)?.let {
             if (rescan) {
                 openSearchService.saveRepositoriesInfo(sequenceOf(it.apply { scanRequired = true }))
@@ -141,99 +175,108 @@ class IndexerServiceImpl(
     }
 
     @Scheduled(cron = "#{ @opensearchIndexScheduleRepositoriesRescanCron }")
-    private fun scheduleRepositoriesRescan() = if (isMaster) {
-        try {
-            val repositoriesInfo = openSearchService.getRepositoriesInfo().map {
-                it.apply { scanRequired = true }
-            }.toSet() + vcsManager.vcsServices.filter { it.indexing }.flatMap { vcsService ->
-                vcsService.getRepositories().map { RepositoryInfoDocument(it.toDocument(vcsService)) }
+    private fun scheduleRepositoriesRescan() =
+        if (isMaster) {
+            try {
+                val repositoriesInfo = openSearchService
+                    .getRepositoriesInfo()
+                    .map {
+                        it.apply { scanRequired = true }
+                    }.toSet() + vcsManager.vcsServices.filter { it.indexing }.flatMap { vcsService ->
+                    vcsService.getRepositories().map { RepositoryInfoDocument(it.toDocument(vcsService)) }
+                }
+                if (log.isTraceEnabled) {
+                    log.trace("Scheduled {} repositories for scan: {}", repositoriesInfo.size, repositoriesInfo)
+                } else {
+                    log.debug("Scheduled {} repositories for scan", repositoriesInfo.size)
+                }
+                openSearchService.saveRepositoriesInfo(repositoriesInfo.asSequence())
+            } catch (e: Exception) {
+                log.error("Unable to schedule repositories for rescan", e)
             }
-            if (log.isTraceEnabled) {
-                log.trace("Scheduled {} repositories for scan: {}", repositoriesInfo.size, repositoriesInfo)
-            } else {
-                log.debug("Scheduled {} repositories for scan", repositoriesInfo.size)
-            }
-            openSearchService.saveRepositoriesInfo(repositoriesInfo.asSequence())
-        } catch (e: Exception) {
-            log.error("Unable to schedule repositories for rescan", e)
+        } else {
+            log.trace("Suppress repositories rescan scheduling on non-master instance")
         }
-    } else {
-        log.trace("Suppress repositories rescan scheduling on non-master instance")
-    }
 
     private val repositoryScanQueue = mutableMapOf<RepositoryInfoDocument, Future<*>>()
 
     @Scheduled(fixedDelayString = "#{ @opensearchIndexSubmitScheduledRepositoriesScanFixedDelay }")
-    private fun submitScheduledRepositoriesScan() = if (isMaster) {
-        try {
-            repositoryScanQueue.filterValues { it.isDone }.keys.forEach {
-                repositoryScanQueue.remove(it)
-            }
-            openSearchService.getRepositoriesInfo(scanRequired = true).forEach {
-                repositoryScanQueue.computeIfAbsent(it) { repositoryInfoDocument ->
-                    opensearchIndexScanExecutor.submit { scan(repositoryInfoDocument.repository) }
+    private fun submitScheduledRepositoriesScan() =
+        if (isMaster) {
+            try {
+                repositoryScanQueue.filterValues { it.isDone }.keys.forEach {
+                    repositoryScanQueue.remove(it)
                 }
-            }
-            if (log.isTraceEnabled) {
-                log.trace("{} repositories in scan queue: {}", repositoryScanQueue.size, repositoryScanQueue.keys)
-            } else {
-                log.debug("{} repositories in scan queue", repositoryScanQueue.size)
-            }
-        } catch (e: Exception) {
-            log.error("Unable to submit repositories for scan", e)
-        }
-    } else {
-        log.trace("Suppress repositories scan submitting on non-master instance")
-    }
-
-    private fun scan(repositoryDocument: RepositoryDocument) = try {
-        val vcsService = vcsManager.findVcsServiceById(repositoryDocument.vcsServiceId)
-        val foundRepositoryDocument = vcsService?.let {
-            if (it.indexing) it.findRepository(repositoryDocument.group, repositoryDocument.name)?.toDocument(it)
-            else null
-        }
-        if (foundRepositoryDocument == repositoryDocument) { //IMPORTANT: found repository could be renamed one
-            with(RepositoryInfoDocument(foundRepositoryDocument, false, Date())) {
-                log.debug("Update {} repository info in index", repository.sshUrl)
-                openSearchService.saveRepositoriesInfo(sequenceOf(this))
-                log.debug("Update {} repository refs in index", repository.sshUrl)
-                val foundRefsIds = openSearchService.findRefsIdsByRepositoryId(repository.id)
-                val savedBranchesIds = openSearchService.saveRefs(
-                    vcsService.getBranches(repository.group, repository.name).map { it.toDocument(repository) }
-                )
-                val savedTagsIds = openSearchService.saveRefs(
-                    vcsService.getTags(repository.group, repository.name).map { it.toDocument(repository) }
-                )
-                openSearchService.deleteRefsByIds(foundRefsIds - savedBranchesIds - savedTagsIds)
-                log.debug("Update {} repository commits in index", repository.sshUrl)
-                val foundCommitsIds = openSearchService.findCommitsIdsByRepositoryId(repository.id)
-                val savedCommitsIds = openSearchService.saveCommits(
-                    vcsService.getBranchesCommitGraph(repository.group, repository.name)
-                        .map { it.toDocument(repository) }
-                )
-                openSearchService.deleteCommitsByIds(foundCommitsIds - savedCommitsIds)
-                log.debug("Update {} repository pull requests in index", repository.sshUrl)
-                val foundPullRequestsIds = openSearchService.findPullRequestsIdsByRepositoryId(repository.id)
-                val savedPullRequestsIds = openSearchService.savePullRequests(
-                    vcsService.getPullRequests(repository.group, repository.name).map { it.toDocument(repository) }
-                )
-                openSearchService.deletePullRequestsByIds(foundPullRequestsIds - savedPullRequestsIds)
+                openSearchService.getRepositoriesInfo(scanRequired = true).forEach {
+                    repositoryScanQueue.computeIfAbsent(it) { repositoryInfoDocument ->
+                        opensearchIndexScanExecutor.submit { scan(repositoryInfoDocument.repository) }
+                    }
+                }
+                if (log.isTraceEnabled) {
+                    log.trace("{} repositories in scan queue: {}", repositoryScanQueue.size, repositoryScanQueue.keys)
+                } else {
+                    log.debug("{} repositories in scan queue", repositoryScanQueue.size)
+                }
+            } catch (e: Exception) {
+                log.error("Unable to submit repositories for scan", e)
             }
         } else {
-            log.debug("Remove {} repository pull-requests from index", repositoryDocument.sshUrl)
-            openSearchService.deletePullRequestsByRepositoryId(repositoryDocument.id)
-            log.debug("Remove {} repository commits from index", repositoryDocument.sshUrl)
-            openSearchService.deleteCommitsByRepositoryId(repositoryDocument.id)
-            log.debug("Remove {} repository refs from index", repositoryDocument.sshUrl)
-            openSearchService.deleteRefsByRepositoryId(repositoryDocument.id)
-            log.debug("Remove {} repository info from index", repositoryDocument.sshUrl)
-            openSearchService.deleteRepositoryInfoById(repositoryDocument.id)
+            log.trace("Suppress repositories scan submitting on non-master instance")
         }
-        log.info("Scanning of {} repository completed successfully", repositoryDocument.sshUrl)
-    } catch (e: Exception) {
-        log.error("Scanning of ${repositoryDocument.sshUrl} repository ended in failure", e)
-        openSearchService.saveRepositoriesInfo(sequenceOf(RepositoryInfoDocument(repositoryDocument)))
-    }
+
+    private fun scan(repositoryDocument: RepositoryDocument) =
+        try {
+            val vcsService = vcsManager.findVcsServiceById(repositoryDocument.vcsServiceId)
+            val foundRepositoryDocument = vcsService?.let {
+                if (it.indexing) {
+                    it.findRepository(repositoryDocument.group, repositoryDocument.name)?.toDocument(it)
+                } else {
+                    null
+                }
+            }
+            if (foundRepositoryDocument == repositoryDocument) { // IMPORTANT: found repository could be renamed one
+                with(RepositoryInfoDocument(foundRepositoryDocument, false, Date())) {
+                    log.debug("Update {} repository info in index", repository.sshUrl)
+                    openSearchService.saveRepositoriesInfo(sequenceOf(this))
+                    log.debug("Update {} repository refs in index", repository.sshUrl)
+                    val foundRefsIds = openSearchService.findRefsIdsByRepositoryId(repository.id)
+                    val savedBranchesIds = openSearchService.saveRefs(
+                        vcsService.getBranches(repository.group, repository.name).map { it.toDocument(repository) },
+                    )
+                    val savedTagsIds = openSearchService.saveRefs(
+                        vcsService.getTags(repository.group, repository.name).map { it.toDocument(repository) },
+                    )
+                    openSearchService.deleteRefsByIds(foundRefsIds - savedBranchesIds - savedTagsIds)
+                    log.debug("Update {} repository commits in index", repository.sshUrl)
+                    val foundCommitsIds = openSearchService.findCommitsIdsByRepositoryId(repository.id)
+                    val savedCommitsIds = openSearchService.saveCommits(
+                        vcsService
+                            .getBranchesCommitGraph(repository.group, repository.name)
+                            .map { it.toDocument(repository) },
+                    )
+                    openSearchService.deleteCommitsByIds(foundCommitsIds - savedCommitsIds)
+                    log.debug("Update {} repository pull requests in index", repository.sshUrl)
+                    val foundPullRequestsIds = openSearchService.findPullRequestsIdsByRepositoryId(repository.id)
+                    val savedPullRequestsIds = openSearchService.savePullRequests(
+                        vcsService.getPullRequests(repository.group, repository.name).map { it.toDocument(repository) },
+                    )
+                    openSearchService.deletePullRequestsByIds(foundPullRequestsIds - savedPullRequestsIds)
+                }
+            } else {
+                log.debug("Remove {} repository pull-requests from index", repositoryDocument.sshUrl)
+                openSearchService.deletePullRequestsByRepositoryId(repositoryDocument.id)
+                log.debug("Remove {} repository commits from index", repositoryDocument.sshUrl)
+                openSearchService.deleteCommitsByRepositoryId(repositoryDocument.id)
+                log.debug("Remove {} repository refs from index", repositoryDocument.sshUrl)
+                openSearchService.deleteRefsByRepositoryId(repositoryDocument.id)
+                log.debug("Remove {} repository info from index", repositoryDocument.sshUrl)
+                openSearchService.deleteRepositoryInfoById(repositoryDocument.id)
+            }
+            log.info("Scanning of {} repository completed successfully", repositoryDocument.sshUrl)
+        } catch (e: Exception) {
+            log.error("Scanning of ${repositoryDocument.sshUrl} repository ended in failure", e)
+            openSearchService.saveRepositoriesInfo(sequenceOf(RepositoryInfoDocument(repositoryDocument)))
+        }
 
     companion object {
         private val log = LoggerFactory.getLogger(IndexerServiceImpl::class.java)

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/OpenSearchServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/OpenSearchServiceImpl.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.vcsfacade.service.impl
 
-import kotlin.jvm.optionals.getOrNull
 import org.octopusden.octopus.vcsfacade.client.common.dto.RefType
 import org.octopusden.octopus.vcsfacade.client.common.dto.SearchSummary
 import org.octopusden.octopus.vcsfacade.document.BaseDocument
@@ -17,16 +16,20 @@ import org.octopusden.octopus.vcsfacade.service.OpenSearchService
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 @ConditionalOnProperty(
-    prefix = "vcs-facade.opensearch", name = ["enabled"], havingValue = "true", matchIfMissing = true
+    prefix = "vcs-facade.opensearch",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
 )
 class OpenSearchServiceImpl(
     private val repositoryInfoRepository: RepositoryInfoRepository,
     private val refRepository: RefRepository,
     private val commitRepository: CommitRepository,
-    private val pullRequestRepository: PullRequestRepository
+    private val pullRequestRepository: PullRequestRepository,
 ) : OpenSearchService {
     override fun getRepositoriesInfo(scanRequired: Boolean?): Set<RepositoryInfoDocument> {
         log.trace("=> getRepositoriesInfo({})", scanRequired)
@@ -137,66 +140,84 @@ class OpenSearchServiceImpl(
 
     override fun findBranchesByIssueKeys(issueKeys: Set<String>): Set<RefDocument> {
         log.trace("=> findBranchesByIssueKeys({})", issueKeys)
-        return issueKeys.flatMap { issueKey ->
-            val issueKeyRegex = IssueKeyParser.getIssueKeyRegex(issueKey)
-            refRepository.searchByTypeAndNameContaining(RefType.BRANCH, issueKey)
-                .filter { issueKeyRegex.containsMatchIn(it.name) }
-        }.toSet().also {
-            log.trace("<= findBranchesByIssueKeys({}): {}", issueKeys, it)
-        }
+        return issueKeys
+            .flatMap { issueKey ->
+                val issueKeyRegex = IssueKeyParser.getIssueKeyRegex(issueKey)
+                refRepository
+                    .searchByTypeAndNameContaining(RefType.BRANCH, issueKey)
+                    .filter { issueKeyRegex.containsMatchIn(it.name) }
+            }.toSet()
+            .also {
+                log.trace("<= findBranchesByIssueKeys({}): {}", issueKeys, it)
+            }
     }
 
     override fun findCommitsByIssueKeys(issueKeys: Set<String>): Set<CommitDocument> {
         log.trace("=> findCommitsByIssueKeys({})", issueKeys)
-        return issueKeys.flatMap { issueKey ->
-            val issueKeyRegex = IssueKeyParser.getIssueKeyRegex(issueKey)
-            commitRepository.searchByMessageContaining(issueKey)
-                .filter { issueKeyRegex.containsMatchIn(it.message) }
-        }.toSet().also {
-            log.trace("<= findCommitsByIssueKeys({}): {}", issueKeys, it)
-        }
+        return issueKeys
+            .flatMap { issueKey ->
+                val issueKeyRegex = IssueKeyParser.getIssueKeyRegex(issueKey)
+                commitRepository
+                    .searchByMessageContaining(issueKey)
+                    .filter { issueKeyRegex.containsMatchIn(it.message) }
+            }.toSet()
+            .also {
+                log.trace("<= findCommitsByIssueKeys({}): {}", issueKeys, it)
+            }
     }
 
     override fun findPullRequestsByIssueKeys(issueKeys: Set<String>): Set<PullRequestDocument> {
         log.trace("=> findPullRequestsByIssueKeys({})", issueKeys)
-        return issueKeys.flatMap { issueKey ->
-            val issueKeyRegex = IssueKeyParser.getIssueKeyRegex(issueKey)
-            pullRequestRepository.searchByTitleContainingOrDescriptionContaining(issueKey, issueKey)
-                .filter { issueKeyRegex.containsMatchIn(it.title) || issueKeyRegex.containsMatchIn(it.description) }
-        }.toSet().also {
-            log.trace("<= findPullRequestsByIssueKeys({}): {}", issueKeys, it)
-        }
+        return issueKeys
+            .flatMap { issueKey ->
+                val issueKeyRegex = IssueKeyParser.getIssueKeyRegex(issueKey)
+                pullRequestRepository
+                    .searchByTitleContainingOrDescriptionContaining(issueKey, issueKey)
+                    .filter { issueKeyRegex.containsMatchIn(it.title) || issueKeyRegex.containsMatchIn(it.description) }
+            }.toSet()
+            .also {
+                log.trace("<= findPullRequestsByIssueKeys({}): {}", issueKeys, it)
+            }
     }
 
     override fun findByIssueKeys(issueKeys: Set<String>): SearchSummary {
         log.trace("=> findByIssueKeys({})", issueKeys)
         val issueKeysToRegex = issueKeys.map { it to IssueKeyParser.getIssueKeyRegex(it) }
-        val branchesCommits = issueKeysToRegex.flatMap { (issueKey, regex) ->
-            refRepository.searchByTypeAndNameContaining(RefType.BRANCH, issueKey).filter {
-                regex.containsMatchIn(it.name)
-            }.map {
-                commitRepository.findById(it.commitId).getOrNull()
-            }
-        }.toSet()
-        val commits = issueKeysToRegex.flatMap { (issueKey, regex) ->
-            commitRepository.searchByMessageContaining(issueKey).filter {
-                regex.containsMatchIn(it.message)
-            }
-        }.toSet()
-        val pullRequests = issueKeysToRegex.flatMap { (issueKey, regex) ->
-            pullRequestRepository.searchByTitleContainingOrDescriptionContaining(issueKey, issueKey).filter {
-                regex.containsMatchIn(it.title) || regex.containsMatchIn(it.description)
-            }
-        }.toSet()
-        return SearchSummary(SearchSummary.SearchBranchesSummary(
-            branchesCommits.size,
-            branchesCommits.filterNotNull().maxOfOrNull { it.date }),
+        val branchesCommits = issueKeysToRegex
+            .flatMap { (issueKey, regex) ->
+                refRepository
+                    .searchByTypeAndNameContaining(RefType.BRANCH, issueKey)
+                    .filter {
+                        regex.containsMatchIn(it.name)
+                    }.map {
+                        commitRepository.findById(it.commitId).getOrNull()
+                    }
+            }.toSet()
+        val commits = issueKeysToRegex
+            .flatMap { (issueKey, regex) ->
+                commitRepository.searchByMessageContaining(issueKey).filter {
+                    regex.containsMatchIn(it.message)
+                }
+            }.toSet()
+        val pullRequests = issueKeysToRegex
+            .flatMap { (issueKey, regex) ->
+                pullRequestRepository.searchByTitleContainingOrDescriptionContaining(issueKey, issueKey).filter {
+                    regex.containsMatchIn(it.title) || regex.containsMatchIn(it.description)
+                }
+            }.toSet()
+        return SearchSummary(
+            SearchSummary.SearchBranchesSummary(
+                branchesCommits.size,
+                branchesCommits.filterNotNull().maxOfOrNull { it.date },
+            ),
             SearchSummary.SearchCommitsSummary(commits.size, commits.maxOfOrNull { it.date }),
-            SearchSummary.SearchPullRequestsSummary(pullRequests.size,
+            SearchSummary.SearchPullRequestsSummary(
+                pullRequests.size,
                 pullRequests.maxOfOrNull { it.updatedAt },
                 with(pullRequests.map { it.status }.toSet()) {
                     if (size == 1) first() else null
-                })
+                },
+            ),
         ).also {
             log.trace("<= findByIssueKeys({}): {}", issueKeys, it)
         }
@@ -205,7 +226,7 @@ class OpenSearchServiceImpl(
     companion object {
         private val log = LoggerFactory.getLogger(OpenSearchServiceImpl::class.java)
 
-        private const val BATCH_SIZE = 50 //must be equal to search limit in repositories
+        private const val BATCH_SIZE = 50 // must be equal to search limit in repositories
 
         /* IMPORTANT: use raw `search_after` approach because:
          * - native query builder required to use `search_after` with PIT or to `scroll` (spring-data-opensearch does not fully support Spring Data JPA Scroll API)
@@ -236,14 +257,16 @@ class OpenSearchServiceImpl(
             return documentsIds
         }
 
-        private fun <T : BaseDocument> processAll(documents: Sequence<T>, batchOperation: (batch: List<T>) -> Unit) =
-            processAll(documents, BATCH_SIZE, { 1 }, batchOperation)
+        private fun <T : BaseDocument> processAll(
+            documents: Sequence<T>,
+            batchOperation: (batch: List<T>) -> Unit,
+        ) = processAll(documents, BATCH_SIZE, { 1 }, batchOperation)
 
         private fun <T : BaseDocument> processAll(
             documents: Sequence<T>,
             batchWeightLimit: Int,
             documentWeight: (document: T) -> Int,
-            batchOperation: (batch: List<T>) -> Unit
+            batchOperation: (batch: List<T>) -> Unit,
         ): Set<String> {
             val documentsIds = mutableSetOf<String>()
             val batch = ArrayList<T>(BATCH_SIZE)
@@ -265,10 +288,11 @@ class OpenSearchServiceImpl(
             return documentsIds
         }
 
-        private fun processAllIds(documentsIds: Set<String>, batchOperation: (batch: List<String>) -> Unit) =
-            documentsIds.chunked(BATCH_SIZE).forEach {
-                batchOperation.invoke(it)
-            }
-
+        private fun processAllIds(
+            documentsIds: Set<String>,
+            batchOperation: (batch: List<String>) -> Unit,
+        ) = documentsIds.chunked(BATCH_SIZE).forEach {
+            batchOperation.invoke(it)
+        }
     }
 }

--- a/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/VcsManagerImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/octopus/vcsfacade/service/impl/VcsManagerImpl.kt
@@ -1,7 +1,5 @@
 package org.octopusden.octopus.vcsfacade.service.impl
 
-import java.util.Date
-import java.util.stream.Collectors
 import org.octopusden.octopus.vcsfacade.client.common.dto.Branch
 import org.octopusden.octopus.vcsfacade.client.common.dto.Commit
 import org.octopusden.octopus.vcsfacade.client.common.dto.CommitWithFiles
@@ -25,161 +23,216 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.stereotype.Service
+import java.util.Date
+import java.util.stream.Collectors
 
 @Service
 class VcsManagerImpl(
     private val vcsProperties: VcsProperties,
     private val openSearchService: OpenSearchService?,
-) : VcsManager, HealthIndicator {
-    private val vcsServiceMap = vcsProperties.services.map {
-        when (it.type) {
-            VcsServiceType.BITBUCKET -> BitbucketService(it)
-            VcsServiceType.GITEA -> GiteaService(it)
+) : VcsManager,
+    HealthIndicator {
+    private val vcsServiceMap = vcsProperties.services
+        .map {
+            when (it.type) {
+                VcsServiceType.BITBUCKET -> BitbucketService(it)
+                VcsServiceType.GITEA -> GiteaService(it)
+            }
+        }.groupBy { it.id }
+        .mapValues {
+            if (it.value.size > 1) {
+                throw IllegalStateException("${it.value.size} VCS services have similar id '${it.key}'")
+            } else {
+                it.value.first()
+            }
         }
-    }.groupBy { it.id }.mapValues {
-        if (it.value.size > 1) throw IllegalStateException("${it.value.size} VCS services have similar id '${it.key}'")
-        else it.value.first()
-    }
 
     override val vcsServices = vcsServiceMap.values
 
     override fun findVcsServiceById(id: String) = vcsServiceMap[id.lowercase()]
 
-    override fun getVcsServiceById(id: String) = findVcsServiceById(id)
-        ?: throw IllegalStateException("There is no configured VCS service with id '$id'")
+    override fun getVcsServiceById(id: String) =
+        findVcsServiceById(id)
+            ?: throw IllegalStateException("There is no configured VCS service with id '$id'")
 
-    override fun getVcsServiceForSshUrl(sshUrl: String) = vcsServices.firstOrNull { it.isSupported(sshUrl) }
-        ?: throw IllegalStateException("There is no configured VCS service for '$sshUrl'")
+    override fun getVcsServiceForSshUrl(sshUrl: String) =
+        vcsServices.firstOrNull { it.isSupported(sshUrl) }
+            ?: throw IllegalStateException("There is no configured VCS service for '$sshUrl'")
 
-    override fun getTags(sshUrl: String, names: Set<String>?): Sequence<Tag> {
+    override fun getTags(
+        sshUrl: String,
+        names: Set<String>?,
+    ): Sequence<Tag> {
         log.trace("=> getTags({}, {})", sshUrl, names)
-        return getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            if (names == null) {
-                getTags(group, repository)
-            } else {
-                findTags(group, repository, names)
-            }
-        }.also { if (log.isTraceEnabled) log.trace("<= getTags({}, {}): {}", sshUrl, names, it.toList()) }
+        return getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                if (names == null) {
+                    getTags(group, repository)
+                } else {
+                    findTags(group, repository, names)
+                }
+            }.also { if (log.isTraceEnabled) log.trace("<= getTags({}, {}): {}", sshUrl, names, it.toList()) }
     }
 
-    override fun createTag(sshUrl: String, createTag: CreateTag): Tag {
+    override fun createTag(
+        sshUrl: String,
+        createTag: CreateTag,
+    ): Tag {
         log.trace("=> createTag({}, {})", sshUrl, createTag)
-        return getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            createTag(group, repository, createTag)
-        }.also { log.trace("<= getTags({}, {}): {}", sshUrl, createTag, it) }
+        return getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                createTag(group, repository, createTag)
+            }.also { log.trace("<= getTags({}, {}): {}", sshUrl, createTag, it) }
     }
 
-    override fun getTag(sshUrl: String, name: String): Tag {
+    override fun getTag(
+        sshUrl: String,
+        name: String,
+    ): Tag {
         log.trace("=> getTag({}, {})", sshUrl, name)
-        return getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            getTag(group, repository, name)
-        }.also { log.trace("<= getTag({}, {}): {}", sshUrl, name, it) }
+        return getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                getTag(group, repository, name)
+            }.also { log.trace("<= getTag({}, {}): {}", sshUrl, name, it) }
     }
 
-    override fun deleteTag(sshUrl: String, name: String) {
+    override fun deleteTag(
+        sshUrl: String,
+        name: String,
+    ) {
         log.trace("=> deleteTag({}, {})", sshUrl, name)
-        getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            deleteTag(group, repository, name)
-        }.also { log.trace("<= deleteTag({}, {})", sshUrl, name) }
+        getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                deleteTag(group, repository, name)
+            }.also { log.trace("<= deleteTag({}, {})", sshUrl, name) }
     }
 
     override fun getCommits(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ): Sequence<Commit> {
         log.trace("=> getCommits({}, {}, {}, {})", sshUrl, fromHashOrRef, fromDate, toHashOrRef)
-        return getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            getCommits(group, repository, HashOrRefOrDate.create(fromHashOrRef, fromDate), toHashOrRef)
-        }.also {
-            if (log.isTraceEnabled) log.trace(
-                "<= getCommits({}, {}, {}, {}): {}",
-                sshUrl,
-                fromHashOrRef,
-                fromDate,
-                toHashOrRef,
-                it.toList()
-            )
-        }
+        return getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                getCommits(group, repository, HashOrRefOrDate.create(fromHashOrRef, fromDate), toHashOrRef)
+            }.also {
+                if (log.isTraceEnabled) {
+                    log.trace(
+                        "<= getCommits({}, {}, {}, {}): {}",
+                        sshUrl,
+                        fromHashOrRef,
+                        fromDate,
+                        toHashOrRef,
+                        it.toList(),
+                    )
+                }
+            }
     }
 
     override fun getCommitsWithFiles(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
-        toHashOrRef: String
+        toHashOrRef: String,
     ): Sequence<CommitWithFiles> {
         log.trace("=> getCommitsWithFiles({}, {}, {}, {})", sshUrl, fromHashOrRef, fromDate, toHashOrRef)
-        return getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            getCommitsWithFiles(group, repository, HashOrRefOrDate.create(fromHashOrRef, fromDate), toHashOrRef)
-        }.also {
-            if (log.isTraceEnabled) log.trace(
-                "<= getCommitsWithFiles({}, {}, {}, {}): {}",
-                sshUrl,
-                fromHashOrRef,
-                fromDate,
-                toHashOrRef,
-                it.toList()
-            )
-        }
+        return getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                getCommitsWithFiles(group, repository, HashOrRefOrDate.create(fromHashOrRef, fromDate), toHashOrRef)
+            }.also {
+                if (log.isTraceEnabled) {
+                    log.trace(
+                        "<= getCommitsWithFiles({}, {}, {}, {}): {}",
+                        sshUrl,
+                        fromHashOrRef,
+                        fromDate,
+                        toHashOrRef,
+                        it.toList(),
+                    )
+                }
+            }
     }
 
-    override fun getCommit(sshUrl: String, hashOrRef: String): Commit {
+    override fun getCommit(
+        sshUrl: String,
+        hashOrRef: String,
+    ): Commit {
         log.trace("=> getCommit({}, {})", sshUrl, hashOrRef)
-        return getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            getCommit(group, repository, hashOrRef)
-        }.also { log.trace("<= getCommit({}, {}): {}", sshUrl, hashOrRef, it) }
+        return getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                getCommit(group, repository, hashOrRef)
+            }.also { log.trace("<= getCommit({}, {}): {}", sshUrl, hashOrRef, it) }
     }
 
-    override fun getCommitWithFiles(sshUrl: String, hashOrRef: String): CommitWithFiles {
+    override fun getCommitWithFiles(
+        sshUrl: String,
+        hashOrRef: String,
+    ): CommitWithFiles {
         log.trace("=> getCommitWithFiles({}, {})", sshUrl, hashOrRef)
-        return getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            getCommitWithFiles(group, repository, hashOrRef)
-        }.also { log.trace("<= getCommitWithFiles({}, {}): {}", sshUrl, hashOrRef, it) }
+        return getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                getCommitWithFiles(group, repository, hashOrRef)
+            }.also { log.trace("<= getCommitWithFiles({}, {}): {}", sshUrl, hashOrRef, it) }
     }
 
-    override fun createPullRequest(sshUrl: String, createPullRequest: CreatePullRequest): PullRequest {
+    override fun createPullRequest(
+        sshUrl: String,
+        createPullRequest: CreatePullRequest,
+    ): PullRequest {
         log.trace("=> createPullRequest({}, {})", sshUrl, createPullRequest)
-        return getVcsServiceForSshUrl(sshUrl).run {
-            val (group, repository) = parse(sshUrl)
-            createPullRequest(group, repository, createPullRequest)
-        }.also { log.trace("<= createPullRequest({}, {}): {}", sshUrl, createPullRequest, it) }
+        return getVcsServiceForSshUrl(sshUrl)
+            .run {
+                val (group, repository) = parse(sshUrl)
+                createPullRequest(group, repository, createPullRequest)
+            }.also { log.trace("<= createPullRequest({}, {}): {}", sshUrl, createPullRequest, it) }
     }
 
     override fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest): SearchIssueInRangesResponse {
         log.trace("=> searchIssuesInRanges({})", searchRequest)
         validateIssueKeys(searchRequest.issueKeys)
-        val messageRanges = searchRequest.ranges.flatMap { range ->
-            getCommits(
-                range.sshUrl, range.fromHashOrRef, range.fromDate, range.toHashOrRef
-            ).map { commit ->
-                commit.message to RepositoryRange(
-                    commit.repository.sshUrl,
+        val messageRanges = searchRequest.ranges
+            .flatMap { range ->
+                getCommits(
+                    range.sshUrl,
                     range.fromHashOrRef,
                     range.fromDate,
-                    range.toHashOrRef
-                )
-            }
-        }.groupBy({ (message, _) -> message }, { (_, range) -> range })
-        return SearchIssueInRangesResponse(searchRequest.issueKeys.map { issueKey ->
-            val issueKeyRegex = IssueKeyParser.getIssueKeyRegex(issueKey)
-            issueKey to messageRanges.entries.filter { (message, _) -> issueKeyRegex.containsMatchIn(message) }
-                .flatMap { (_, ranges) -> ranges }
-        }.groupBy({ (issueKey, _) -> issueKey }, { (_, ranges) -> ranges }).entries.stream()
-            .collect(
-                Collectors.toMap({ (issueKey, _) -> issueKey },
-                    { (_, ranges) -> ranges.flatten().toSet() },
-                    { a, b -> a + b })
-            ).filter { (_, ranges) -> ranges.isNotEmpty() }
+                    range.toHashOrRef,
+                ).map { commit ->
+                    commit.message to RepositoryRange(
+                        commit.repository.sshUrl,
+                        range.fromHashOrRef,
+                        range.fromDate,
+                        range.toHashOrRef,
+                    )
+                }
+            }.groupBy({ (message, _) -> message }, { (_, range) -> range })
+        return SearchIssueInRangesResponse(
+            searchRequest.issueKeys
+                .map { issueKey ->
+                    val issueKeyRegex = IssueKeyParser.getIssueKeyRegex(issueKey)
+                    issueKey to messageRanges.entries
+                        .filter { (message, _) -> issueKeyRegex.containsMatchIn(message) }
+                        .flatMap { (_, ranges) -> ranges }
+                }.groupBy({ (issueKey, _) -> issueKey }, { (_, ranges) -> ranges })
+                .entries
+                .stream()
+                .collect(
+                    Collectors.toMap(
+                        { (issueKey, _) -> issueKey },
+                        { (_, ranges) -> ranges.flatten().toSet() },
+                        { a, b -> a + b },
+                    ),
+                ).filter { (_, ranges) -> ranges.isNotEmpty() },
         ).also { log.trace("<= searchIssuesInRanges({}): {}", searchRequest, it) }
     }
 
@@ -187,8 +240,10 @@ class VcsManagerImpl(
         log.trace("=> findBranches({})", issueKeys)
         validateIssueKeys(issueKeys)
         val branches = openSearchService?.findBranchesByIssueKeys(issueKeys)?.asSequence()?.map { it.toDto() as Branch }
-            ?: issueKeys.flatMap { issueKey -> vcsServices.flatMap { it.findBranches(issueKey) } }
-                .asSequence().distinctBy { it.repository.sshUrl + it.name }
+            ?: issueKeys
+                .flatMap { issueKey -> vcsServices.flatMap { it.findBranches(issueKey) } }
+                .asSequence()
+                .distinctBy { it.repository.sshUrl + it.name }
         if (log.isTraceEnabled) log.trace("<= findBranches({}): {}", issueKeys, branches.toList())
         return branches
     }
@@ -197,8 +252,10 @@ class VcsManagerImpl(
         log.trace("=> findCommits({})", issueKeys)
         validateIssueKeys(issueKeys)
         val commits = openSearchService?.findCommitsByIssueKeys(issueKeys)?.asSequence()?.map { it.toDto().commit }
-            ?: issueKeys.flatMap { issueKey -> vcsServices.flatMap { it.findCommits(issueKey) } }
-                .asSequence().distinctBy { it.repository.sshUrl + it.hash }
+            ?: issueKeys
+                .flatMap { issueKey -> vcsServices.flatMap { it.findCommits(issueKey) } }
+                .asSequence()
+                .distinctBy { it.repository.sshUrl + it.hash }
         if (log.isTraceEnabled) log.trace("<= findCommits({}): {}", issueKeys, commits.toList())
         return commits
     }
@@ -207,8 +264,10 @@ class VcsManagerImpl(
         log.trace("=> findCommitsWithFiles({})", issueKeys)
         validateIssueKeys(issueKeys)
         val commitsWithFiles = openSearchService?.findCommitsByIssueKeys(issueKeys)?.asSequence()?.map { it.toDto() }
-            ?: issueKeys.flatMap { issueKey -> vcsServices.flatMap { it.findCommitsWithFiles(issueKey) } }
-                .asSequence().distinctBy { it.commit.repository.sshUrl + it.commit.hash }
+            ?: issueKeys
+                .flatMap { issueKey -> vcsServices.flatMap { it.findCommitsWithFiles(issueKey) } }
+                .asSequence()
+                .distinctBy { it.commit.repository.sshUrl + it.commit.hash }
         if (log.isTraceEnabled) log.trace("<= findCommitsWithFiles({}): {}", issueKeys, commitsWithFiles.toList())
         return commitsWithFiles
     }
@@ -217,8 +276,10 @@ class VcsManagerImpl(
         log.trace("=> findPullRequests({})", issueKeys)
         validateIssueKeys(issueKeys)
         val pullRequests = openSearchService?.findPullRequestsByIssueKeys(issueKeys)?.asSequence()?.map { it.toDto() }
-            ?: issueKeys.flatMap { issueKey -> vcsServices.flatMap { it.findPullRequests(issueKey) } }
-                .asSequence().distinctBy { it.repository.sshUrl + it.index }
+            ?: issueKeys
+                .flatMap { issueKey -> vcsServices.flatMap { it.findPullRequests(issueKey) } }
+                .asSequence()
+                .distinctBy { it.repository.sshUrl + it.index }
         if (log.isTraceEnabled) log.trace("<= findPullRequests({}): {}", issueKeys, pullRequests.toList())
         return pullRequests
     }
@@ -227,33 +288,39 @@ class VcsManagerImpl(
         log.trace("=> find({})", issueKeys)
         validateIssueKeys(issueKeys)
         val searchSummary = openSearchService?.findByIssueKeys(issueKeys) ?: run {
-            val branchesCommits = issueKeys.flatMap { issueKey ->
-                vcsServices.flatMap { vcsService ->
-                    vcsService.findBranches(issueKey).groupBy { it.repository.sshUrl }.flatMap {
-                        val (group, repository) = vcsService.parse(it.key)
-                        vcsService.findCommits(group, repository, it.value.map { branch -> branch.hash }.toSet())
+            val branchesCommits = issueKeys
+                .flatMap { issueKey ->
+                    vcsServices.flatMap { vcsService ->
+                        vcsService.findBranches(issueKey).groupBy { it.repository.sshUrl }.flatMap {
+                            val (group, repository) = vcsService.parse(it.key)
+                            vcsService.findCommits(group, repository, it.value.map { branch -> branch.hash }.toSet())
+                        }
                     }
-                }
-            }.distinctBy { it.repository.sshUrl + it.hash }
-            val commits = issueKeys.flatMap { issueKey ->
-                vcsServices.flatMap { it.findCommits(issueKey) }
-            }.distinctBy { it.repository.sshUrl + it.hash }
-            val pullRequests = issueKeys.flatMap { issueKey ->
-                vcsServices.flatMap { it.findPullRequests(issueKey) }
-            }.distinctBy { it.repository.sshUrl + it.index }
+                }.distinctBy { it.repository.sshUrl + it.hash }
+            val commits = issueKeys
+                .flatMap { issueKey ->
+                    vcsServices.flatMap { it.findCommits(issueKey) }
+                }.distinctBy { it.repository.sshUrl + it.hash }
+            val pullRequests = issueKeys
+                .flatMap { issueKey ->
+                    vcsServices.flatMap { it.findPullRequests(issueKey) }
+                }.distinctBy { it.repository.sshUrl + it.index }
             SearchSummary(
                 SearchSummary.SearchBranchesSummary(
                     branchesCommits.size,
-                    branchesCommits.maxOfOrNull { it.date }),
+                    branchesCommits.maxOfOrNull { it.date },
+                ),
                 SearchSummary.SearchCommitsSummary(
                     commits.size,
-                    commits.maxOfOrNull { it.date }),
+                    commits.maxOfOrNull { it.date },
+                ),
                 SearchSummary.SearchPullRequestsSummary(
                     pullRequests.size,
                     pullRequests.maxOfOrNull { it.updatedAt },
                     with(pullRequests.map { it.status }.toSet()) {
                         if (size == 1) first() else null
-                    })
+                    },
+                ),
             )
         }
         log.trace("<= find({}): {}", issueKeys, searchSummary)
@@ -273,12 +340,14 @@ class VcsManagerImpl(
         val errors = healthCheckList.mapNotNull {
             val healthCheck = it.second
             try {
-                val commits = getVcsServiceById(it.first).getCommits(
-                    healthCheck.group,
-                    healthCheck.repository,
-                    HashOrRefOrDate.create(healthCheck.fromCommit, null),
-                    healthCheck.toCommit
-                ).map { commit -> commit.hash }.toSet()
+                val commits = getVcsServiceById(it.first)
+                    .getCommits(
+                        healthCheck.group,
+                        healthCheck.repository,
+                        HashOrRefOrDate.create(healthCheck.fromCommit, null),
+                        healthCheck.toCommit,
+                    ).map { commit -> commit.hash }
+                    .toSet()
                 if (commits != healthCheck.expectedCommits) {
                     val diffCommits = (commits - healthCheck.expectedCommits)
                         .union(healthCheck.expectedCommits - commits)

--- a/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/service/VcsServiceSshUrlParsingTest.kt
+++ b/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/service/VcsServiceSshUrlParsingTest.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.vcsfacade.service
 
-import java.util.Date
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -16,10 +15,13 @@ import org.octopusden.octopus.vcsfacade.client.common.dto.Tag
 import org.octopusden.octopus.vcsfacade.config.VcsProperties
 import org.octopusden.octopus.vcsfacade.dto.HashOrRefOrDate
 import org.octopusden.octopus.vcsfacade.dto.VcsServiceType
+import java.util.Date
 
 class VcsServiceSshUrlParsingTest {
-
-    private fun createService(sshUrl: String, type: VcsServiceType): VcsService {
+    private fun createService(
+        sshUrl: String,
+        type: VcsServiceType,
+    ): VcsService {
         val properties = VcsProperties.Service(
             id = "test",
             type = type,
@@ -28,7 +30,7 @@ class VcsServiceSshUrlParsingTest {
             token = "test-token",
             username = null,
             password = null,
-            healthCheck = null
+            healthCheck = null,
         )
         return StubVcsService(properties)
     }
@@ -101,28 +103,116 @@ class VcsServiceSshUrlParsingTest {
         assertFalse(bitbucketService.isSupported("ssh://git@bitbucketXexampleYcom/project/repo.git"))
     }
 
-    private class StubVcsService(properties: VcsProperties.Service) : VcsService(properties) {
+    private class StubVcsService(
+        properties: VcsProperties.Service,
+    ) : VcsService(properties) {
         override fun getRepositories(): Sequence<Repository> = TODO()
-        override fun findRepository(group: String, repository: String): Repository? = TODO()
-        override fun getBranches(group: String, repository: String): Sequence<Branch> = TODO()
-        override fun getTags(group: String, repository: String): Sequence<Tag> = TODO()
-        override fun createTag(group: String, repository: String, createTag: CreateTag): Tag = TODO()
-        override fun getTag(group: String, repository: String, name: String): Tag = TODO()
-        override fun deleteTag(group: String, repository: String, name: String) = TODO()
-        override fun getCommits(group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String): Sequence<Commit> = TODO()
-        override fun getCommitsWithFiles(group: String, repository: String, from: HashOrRefOrDate<String, Date>?, toHashOrRef: String): Sequence<CommitWithFiles> = TODO()
-        override fun getBranchesCommitGraph(group: String, repository: String): Sequence<CommitWithFiles> = TODO()
-        override fun getCommit(group: String, repository: String, hashOrRef: String): Commit = TODO()
-        override fun getCommitWithFiles(group: String, repository: String, hashOrRef: String): CommitWithFiles = TODO()
-        override fun getPullRequests(group: String, repository: String): Sequence<PullRequest> = TODO()
-        override fun createPullRequest(group: String, repository: String, createPullRequest: CreatePullRequest): PullRequest = TODO()
-        override fun getPullRequest(group: String, repository: String, index: Long): PullRequest = TODO()
-        override fun findTags(group: String, repository: String, names: Set<String>): Sequence<Tag> = TODO()
-        override fun findCommits(group: String, repository: String, hashes: Set<String>): Sequence<Commit> = TODO()
-        override fun findPullRequests(group: String, repository: String, indexes: Set<Long>): Sequence<PullRequest> = TODO()
+
+        override fun findRepository(
+            group: String,
+            repository: String,
+        ): Repository? = TODO()
+
+        override fun getBranches(
+            group: String,
+            repository: String,
+        ): Sequence<Branch> = TODO()
+
+        override fun getTags(
+            group: String,
+            repository: String,
+        ): Sequence<Tag> = TODO()
+
+        override fun createTag(
+            group: String,
+            repository: String,
+            createTag: CreateTag,
+        ): Tag = TODO()
+
+        override fun getTag(
+            group: String,
+            repository: String,
+            name: String,
+        ): Tag = TODO()
+
+        override fun deleteTag(
+            group: String,
+            repository: String,
+            name: String,
+        ) = TODO()
+
+        override fun getCommits(
+            group: String,
+            repository: String,
+            from: HashOrRefOrDate<String, Date>?,
+            toHashOrRef: String,
+        ): Sequence<Commit> = TODO()
+
+        override fun getCommitsWithFiles(
+            group: String,
+            repository: String,
+            from: HashOrRefOrDate<String, Date>?,
+            toHashOrRef: String,
+        ): Sequence<CommitWithFiles> = TODO()
+
+        override fun getBranchesCommitGraph(
+            group: String,
+            repository: String,
+        ): Sequence<CommitWithFiles> = TODO()
+
+        override fun getCommit(
+            group: String,
+            repository: String,
+            hashOrRef: String,
+        ): Commit = TODO()
+
+        override fun getCommitWithFiles(
+            group: String,
+            repository: String,
+            hashOrRef: String,
+        ): CommitWithFiles = TODO()
+
+        override fun getPullRequests(
+            group: String,
+            repository: String,
+        ): Sequence<PullRequest> = TODO()
+
+        override fun createPullRequest(
+            group: String,
+            repository: String,
+            createPullRequest: CreatePullRequest,
+        ): PullRequest = TODO()
+
+        override fun getPullRequest(
+            group: String,
+            repository: String,
+            index: Long,
+        ): PullRequest = TODO()
+
+        override fun findTags(
+            group: String,
+            repository: String,
+            names: Set<String>,
+        ): Sequence<Tag> = TODO()
+
+        override fun findCommits(
+            group: String,
+            repository: String,
+            hashes: Set<String>,
+        ): Sequence<Commit> = TODO()
+
+        override fun findPullRequests(
+            group: String,
+            repository: String,
+            indexes: Set<Long>,
+        ): Sequence<PullRequest> = TODO()
+
         override fun findBranches(issueKey: String): Sequence<Branch> = TODO()
+
         override fun findCommits(issueKey: String): Sequence<Commit> = TODO()
+
         override fun findCommitsWithFiles(issueKey: String): Sequence<CommitWithFiles> = TODO()
+
         override fun findPullRequests(issueKey: String): Sequence<PullRequest> = TODO()
     }
 }

--- a/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/vcs/BaseVcsFacadeUnitTest.kt
+++ b/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/vcs/BaseVcsFacadeUnitTest.kt
@@ -2,9 +2,6 @@ package org.octopusden.octopus.vcsfacade.vcs
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.util.Date
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import org.octopusden.octopus.infrastructure.common.test.TestClient
@@ -30,160 +27,258 @@ import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Date
 
 @AutoConfigureMockMvc
 @ExtendWith(SpringExtension::class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(classes = [VcsFacadeApplication::class], webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 abstract class BaseVcsFacadeUnitTest(
-    testService: TestService, testClient: TestClient
+    testService: TestService,
+    testClient: TestClient,
 ) : BaseVcsFacadeTestExtended(testService, testClient) {
-
     @Autowired
     private lateinit var mvc: MockMvc
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
 
-    override fun createPullRequest(sshUrl: String, createPullRequest: CreatePullRequest) =
-        mvc.perform(
-            MockMvcRequestBuilders.post("/rest/api/2/repository/pull-requests")
+    override fun createPullRequest(
+        sshUrl: String,
+        createPullRequest: CreatePullRequest,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .post("/rest/api/2/repository/pull-requests")
                 .param("sshUrl", sshUrl)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(createPullRequest))
-                .accept(MediaType.APPLICATION_JSON)
-        ).andReturn().response.toObject(object : TypeReference<PullRequest>() {})
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<PullRequest>() {})
 
     override fun getCommits(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
-        toHashOrRef: String
-    ) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/commits")
-            .param("sshUrl", sshUrl)
-            .param("fromHashOrRef", fromHashOrRef)
-            .param("fromDate", fromDate?.toVcsFacadeFormat())
-            .param("toHashOrRef", toHashOrRef)
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<List<Commit>>() {})
+        toHashOrRef: String,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .get("/rest/api/2/repository/commits")
+                .param("sshUrl", sshUrl)
+                .param("fromHashOrRef", fromHashOrRef)
+                .param("fromDate", fromDate?.toVcsFacadeFormat())
+                .param("toHashOrRef", toHashOrRef)
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<List<Commit>>() {})
 
     override fun getCommitsWithFiles(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
         toHashOrRef: String,
-        commitFilesLimit: Int?
-    ) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/commits/files")
-            .param("sshUrl", sshUrl)
-            .param("fromHashOrRef", fromHashOrRef)
-            .param("fromDate", fromDate?.toVcsFacadeFormat())
-            .param("toHashOrRef", toHashOrRef)
-            .param("commitFilesLimit", commitFilesLimit?.toString())
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<List<CommitWithFiles>>() {})
+        commitFilesLimit: Int?,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .get("/rest/api/2/repository/commits/files")
+                .param("sshUrl", sshUrl)
+                .param("fromHashOrRef", fromHashOrRef)
+                .param("fromDate", fromDate?.toVcsFacadeFormat())
+                .param("toHashOrRef", toHashOrRef)
+                .param("commitFilesLimit", commitFilesLimit?.toString())
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<List<CommitWithFiles>>() {})
 
-    override fun getCommit(sshUrl: String, hashOrRef: String) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/commit")
-            .param("sshUrl", sshUrl)
-            .param("hashOrRef", hashOrRef)
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<Commit>() {})
+    override fun getCommit(
+        sshUrl: String,
+        hashOrRef: String,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .get("/rest/api/2/repository/commit")
+                .param("sshUrl", sshUrl)
+                .param("hashOrRef", hashOrRef)
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<Commit>() {})
 
-    override fun getCommitWithFiles(sshUrl: String, hashOrRef: String, commitFilesLimit: Int?) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/commit/files")
-            .param("sshUrl", sshUrl)
-            .param("hashOrRef", hashOrRef)
-            .param("commitFilesLimit", commitFilesLimit?.toString())
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<CommitWithFiles>() {})
+    override fun getCommitWithFiles(
+        sshUrl: String,
+        hashOrRef: String,
+        commitFilesLimit: Int?,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .get("/rest/api/2/repository/commit/files")
+                .param("sshUrl", sshUrl)
+                .param("hashOrRef", hashOrRef)
+                .param("commitFilesLimit", commitFilesLimit?.toString())
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<CommitWithFiles>() {})
 
     override fun getIssuesFromCommits(
         sshUrl: String,
         fromHashOrRef: String?,
         fromDate: Date?,
-        toHashOrRef: String
-    ) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/issues")
-            .param("sshUrl", sshUrl)
-            .param("fromHashOrRef", fromHashOrRef)
-            .param("fromDate", fromDate?.toVcsFacadeFormat())
-            .param("toHashOrRef", toHashOrRef)
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<List<String>>() {})
+        toHashOrRef: String,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .get("/rest/api/2/repository/issues")
+                .param("sshUrl", sshUrl)
+                .param("fromHashOrRef", fromHashOrRef)
+                .param("fromDate", fromDate?.toVcsFacadeFormat())
+                .param("toHashOrRef", toHashOrRef)
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<List<String>>() {})
 
-    override fun getTags(sshUrl: String, names: Set<String>?) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/tags")
-            .param("sshUrl", sshUrl)
-            .apply {
-                if (names != null) {
-                    if (names.isEmpty()) param("names", "")
-                    else param("names", *names.toTypedArray())
-                }
-            }
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<List<Tag>>() {})
+    override fun getTags(
+        sshUrl: String,
+        names: Set<String>?,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .get("/rest/api/2/repository/tags")
+                .param("sshUrl", sshUrl)
+                .apply {
+                    if (names != null) {
+                        if (names.isEmpty()) {
+                            param("names", "")
+                        } else {
+                            param("names", *names.toTypedArray())
+                        }
+                    }
+                }.accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<List<Tag>>() {})
 
-    override fun createTag(sshUrl: String, createTag: CreateTag) = mvc.perform(
-        MockMvcRequestBuilders.post("/rest/api/2/repository/tags")
-            .param("sshUrl", sshUrl)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(createTag))
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<Tag>() {})
+    override fun createTag(
+        sshUrl: String,
+        createTag: CreateTag,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .post("/rest/api/2/repository/tags")
+                .param("sshUrl", sshUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createTag))
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<Tag>() {})
 
-    override fun getTag(sshUrl: String, name: String) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/tag")
-            .param("sshUrl", sshUrl)
-            .param("name", name)
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<Tag>() {})
+    override fun getTag(
+        sshUrl: String,
+        name: String,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .get("/rest/api/2/repository/tag")
+                .param("sshUrl", sshUrl)
+                .param("name", name)
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<Tag>() {})
 
-    override fun deleteTag(sshUrl: String, name: String) = mvc.perform(
-        MockMvcRequestBuilders.delete("/rest/api/2/repository/tag")
-            .param("sshUrl", sshUrl)
-            .param("name", name)
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.decodeError()
+    override fun deleteTag(
+        sshUrl: String,
+        name: String,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .delete("/rest/api/2/repository/tag")
+                .param("sshUrl", sshUrl)
+                .param("name", name)
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .decodeError()
 
-    override fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest) = mvc.perform(
-        MockMvcRequestBuilders.post("/rest/api/2/repository/search-issues-in-ranges")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(searchRequest))
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<SearchIssueInRangesResponse>() {})
+    override fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest) =
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .post("/rest/api/2/repository/search-issues-in-ranges")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(searchRequest))
+                    .accept(MediaType.APPLICATION_JSON),
+            ).andReturn()
+            .response
+            .toObject(object : TypeReference<SearchIssueInRangesResponse>() {})
 
-    override fun findByIssueKeys(issueKeys: Set<String>) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/find")
-            .param("issueKeys", *issueKeys.toTypedArray())
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<SearchSummary>() {})
+    override fun findByIssueKeys(issueKeys: Set<String>) =
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/rest/api/2/repository/find")
+                    .param("issueKeys", *issueKeys.toTypedArray())
+                    .accept(MediaType.APPLICATION_JSON),
+            ).andReturn()
+            .response
+            .toObject(object : TypeReference<SearchSummary>() {})
 
-    override fun findBranchesByIssueKeys(issueKeys: Set<String>) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/branches/find")
-            .param("issueKeys", *issueKeys.toTypedArray())
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<List<Branch>>() {})
+    override fun findBranchesByIssueKeys(issueKeys: Set<String>) =
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/rest/api/2/repository/branches/find")
+                    .param("issueKeys", *issueKeys.toTypedArray())
+                    .accept(MediaType.APPLICATION_JSON),
+            ).andReturn()
+            .response
+            .toObject(object : TypeReference<List<Branch>>() {})
 
-    override fun findCommitsByIssueKeys(issueKeys: Set<String>) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/commits/find")
-            .param("issueKeys", *issueKeys.toTypedArray())
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<List<Commit>>() {})
+    override fun findCommitsByIssueKeys(issueKeys: Set<String>) =
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/rest/api/2/repository/commits/find")
+                    .param("issueKeys", *issueKeys.toTypedArray())
+                    .accept(MediaType.APPLICATION_JSON),
+            ).andReturn()
+            .response
+            .toObject(object : TypeReference<List<Commit>>() {})
 
-    override fun findCommitsWithFilesByIssueKeys(issueKeys: Set<String>, commitFilesLimit: Int?) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/commits/files/find")
-            .param("issueKeys", *issueKeys.toTypedArray())
-            .param("commitFilesLimit", commitFilesLimit?.toString())
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<List<CommitWithFiles>>() {})
+    override fun findCommitsWithFilesByIssueKeys(
+        issueKeys: Set<String>,
+        commitFilesLimit: Int?,
+    ) = mvc
+        .perform(
+            MockMvcRequestBuilders
+                .get("/rest/api/2/repository/commits/files/find")
+                .param("issueKeys", *issueKeys.toTypedArray())
+                .param("commitFilesLimit", commitFilesLimit?.toString())
+                .accept(MediaType.APPLICATION_JSON),
+        ).andReturn()
+        .response
+        .toObject(object : TypeReference<List<CommitWithFiles>>() {})
 
-    override fun findPullRequestsByIssueKeys(issueKeys: Set<String>) = mvc.perform(
-        MockMvcRequestBuilders.get("/rest/api/2/repository/pull-requests/find")
-            .param("issueKeys", *issueKeys.toTypedArray())
-            .accept(MediaType.APPLICATION_JSON)
-    ).andReturn().response.toObject(object : TypeReference<List<PullRequest>>() {})
+    override fun findPullRequestsByIssueKeys(issueKeys: Set<String>) =
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("/rest/api/2/repository/pull-requests/find")
+                    .param("issueKeys", *issueKeys.toTypedArray())
+                    .accept(MediaType.APPLICATION_JSON),
+            ).andReturn()
+            .response
+            .toObject(object : TypeReference<List<PullRequest>>() {})
 
     private fun MockHttpServletResponse.decodeError() {
         if (status / 100 != 2) {
@@ -209,11 +304,10 @@ abstract class BaseVcsFacadeUnitTest(
         val vcsHost: String = System.getProperty("test.vcs-host")
             ?: throw Exception("System property 'test.vcs-host' must be defined")
 
-        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+        private val DATE_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
             .withZone(ZoneId.systemDefault())
 
-        private fun Date.toVcsFacadeFormat(): String {
-            return DATE_FORMATTER.format(toInstant())
-        }
+        private fun Date.toVcsFacadeFormat(): String = DATE_FORMATTER.format(toInstant())
     }
 }

--- a/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/vcs/VcsFacadeUnitTestBitbucket.kt
+++ b/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/vcs/VcsFacadeUnitTestBitbucket.kt
@@ -4,9 +4,9 @@ import org.octopusden.octopus.infastructure.bitbucket.test.BitbucketTestClient
 import org.octopusden.octopus.vcsfacade.TestService
 import org.springframework.test.context.junit.jupiter.EnabledIf
 
-
 @EnabledIf("#{environment.getActiveProfiles().$[#this == 'bitbucket'] == 'bitbucket'}", loadContext = true)
-class VcsFacadeUnitTestBitbucket : BaseVcsFacadeUnitTest(
-    TestService.Bitbucket(vcsFacadeHost, vcsHost),
-    BitbucketTestClient("http://$vcsHost", BITBUCKET_USER, BITBUCKET_PASSWORD)
-)
+class VcsFacadeUnitTestBitbucket :
+    BaseVcsFacadeUnitTest(
+        TestService.Bitbucket(vcsFacadeHost, vcsHost),
+        BitbucketTestClient("http://$vcsHost", BITBUCKET_USER, BITBUCKET_PASSWORD),
+    )

--- a/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/vcs/VcsFacadeUnitTestGitea.kt
+++ b/server/src/test/kotlin/org/octopusden/octopus/vcsfacade/vcs/VcsFacadeUnitTestGitea.kt
@@ -6,10 +6,11 @@ import org.octopusden.octopus.vcsfacade.TestService
 import org.springframework.test.context.junit.jupiter.EnabledIf
 
 @EnabledIf("#{environment.getActiveProfiles().$[#this == 'gitea'] == 'gitea'}", loadContext = true)
-class VcsFacadeUnitTestGitea : BaseVcsFacadeUnitTest(
-    TestService.Gitea(vcsFacadeHost, vcsHost),
-    GiteaTestClient("http://$vcsHost", GITEA_USER, GITEA_PASSWORD)
-) {
+class VcsFacadeUnitTestGitea :
+    BaseVcsFacadeUnitTest(
+        TestService.Gitea(vcsFacadeHost, vcsHost),
+        GiteaTestClient("http://$vcsHost", GITEA_USER, GITEA_PASSWORD),
+    ) {
     @BeforeAll
     fun beforeAllVcsFacadeUnitTestGitea() {
         (testService as TestService.Gitea).scan(GROUP, REPOSITORY_2)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,10 @@ pluginManagement {
         id("com.bmuschko.docker-spring-boot-application") version (extra["bmuschko-docker-plugin.version"] as String)
         id("org.octopusden.octopus.oc-template") version (extra["octopus-oc-template.version"] as String)
         id("io.github.gradle-nexus.publish-plugin") version "1.1.0" apply false
+        // Octopus quality-gates convention plugin + Kotlin static-analysis tools.
+        id("io.gitlab.arturbosch.detekt") version (extra["detekt.version"] as String)
+        id("org.jlleitschuh.gradle.ktlint") version (extra["ktlint.version"] as String)
+        id("org.octopusden.octopus-quality") version (extra["octopus-quality.version"] as String)
     }
     repositories {
         gradlePluginPortal()

--- a/test-common/detekt-baseline.xml
+++ b/test-common/detekt-baseline.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MaxLineLength:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$"Cannot find commit '9c8daf84e7ed6ea1d32f654362131e26dbf37440' in commit graph for commit 'a933dc6b4fe8e8f66856b4cb9da7f4bf8ad0e017' in 'test:repository'"</ID>
+    <ID>TooGenericExceptionThrown:TestService.kt$TestService$throw RuntimeException("Unable to schedule '$group:$repository' scan")</ID>
+    <ID>TooManyFunctions:BaseVcsFacadeTest.kt$BaseVcsFacadeTest</ID>
+    <ID>TooManyFunctions:BaseVcsFacadeTest.kt$BaseVcsFacadeTest$Companion</ID>
+    <ID>TooManyFunctions:TestService.kt$TestService</ID>
+    <ID>UnusedParameter:BaseVcsFacadeTest.kt$BaseVcsFacadeTest$exceptionClass: Class&lt;out Throwable&gt;</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun createPullRequestFailsArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun createTagFailsArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun findBranchesByIssueKeysArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun findByIssueKeysArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun findByIssueKeysFailsArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun findCommitsByIssueKeysArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun findCommitsWithFilesByIssueKeysArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun findPullRequestsByIssueKeysArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getCommitArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getCommitFailsArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getCommitWithFilesArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getCommitsArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getCommitsFailsArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getCommitsWithFilesArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getIssuesFromCommitsArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getTagFailsArguments()</ID>
+    <ID>UnusedPrivateMember:BaseVcsFacadeTest.kt$BaseVcsFacadeTest.Companion$@JvmStatic private fun getTagsArguments()</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/test-common/ktlint-baseline.xml
+++ b/test-common/ktlint-baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+</baseline>

--- a/test-common/src/main/kotlin/org/octopusden/octopus/vcsfacade/BaseVcsFacadeTest.kt
+++ b/test-common/src/main/kotlin/org/octopusden/octopus/vcsfacade/BaseVcsFacadeTest.kt
@@ -1,8 +1,5 @@
 package org.octopusden.octopus.vcsfacade
 
-import java.io.File
-import java.util.Date
-import java.util.stream.Stream
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
@@ -25,11 +22,14 @@ import org.octopusden.octopus.vcsfacade.client.common.dto.SearchSummary
 import org.octopusden.octopus.vcsfacade.client.common.dto.Tag
 import org.octopusden.octopus.vcsfacade.client.common.exception.ArgumentsNotCompatibleException
 import org.octopusden.octopus.vcsfacade.client.common.exception.NotFoundException
+import java.io.File
+import java.util.Date
+import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class BaseVcsFacadeTest(
     protected val testService: TestService,
-    protected val testClient: TestClient
+    protected val testClient: TestClient,
 ) {
     @BeforeAll
     fun beforeAllBaseVcsFacadeTest() {
@@ -37,26 +37,29 @@ abstract class BaseVcsFacadeTest(
             testService.sshUrl(GROUP, REPOSITORY),
             File.createTempFile("BaseVcsFacadeTest-", "-$GROUP-$REPOSITORY").apply {
                 outputStream().use {
-                    BaseVcsFacadeTest::class.java.classLoader.getResourceAsStream("$GROUP-$REPOSITORY.zip")!!.copyTo(it)
+                    BaseVcsFacadeTest::class.java.classLoader
+                        .getResourceAsStream("$GROUP-$REPOSITORY.zip")!!
+                        .copyTo(it)
                 }
-            }
+            },
         )
         testClient.importRepository(
             testService.sshUrl(GROUP, REPOSITORY_2),
             File.createTempFile("BaseVcsFacadeTest-", "-$GROUP-$REPOSITORY_2").apply {
                 outputStream().use {
-                    BaseVcsFacadeTest::class.java.classLoader.getResourceAsStream("$GROUP-$REPOSITORY_2.zip")!!
+                    BaseVcsFacadeTest::class.java.classLoader
+                        .getResourceAsStream("$GROUP-$REPOSITORY_2.zip")!!
                         .copyTo(it)
                 }
-            }
+            },
         )
         createPullRequest(
             testService.sshUrl(GROUP, REPOSITORY_2),
-            CreatePullRequest("feature/ISSUE-4", "master", "[ISSUE-4] test PR", "Test PR description")
+            CreatePullRequest("feature/ISSUE-4", "master", "[ISSUE-4] test PR", "Test PR description"),
         )
         createPullRequest(
             testService.sshUrl(GROUP, REPOSITORY_2),
-            CreatePullRequest("ISSUE-6-and-ISSUE-7", "master", "ISSUE-6, ISSUE-7 test PR 2", "Test PR 2 description")
+            CreatePullRequest("ISSUE-6-and-ISSUE-7", "master", "ISSUE-6, ISSUE-7 test PR 2", "Test PR 2 description"),
         )
     }
 
@@ -71,7 +74,7 @@ abstract class BaseVcsFacadeTest(
         group: String,
         repository: String,
         createPullRequest: CreatePullRequest,
-        exceptionClass: Class<out Throwable>
+        exceptionClass: Class<out Throwable>,
     ) {
         Assertions.assertThrows(exceptionClass) {
             createPullRequest(testService.sshUrl(group, repository), createPullRequest)
@@ -86,10 +89,10 @@ abstract class BaseVcsFacadeTest(
         fromHashOrRef: String?,
         fromDate: Date?,
         toHashOrRef: String,
-        commitsFile: String
+        commitsFile: String,
     ) = Assertions.assertIterableEquals(
         testService.getCommits(commitsFile),
-        getCommits(testService.sshUrl(group, repository), fromHashOrRef, fromDate, toHashOrRef)
+        getCommits(testService.sshUrl(group, repository), fromHashOrRef, fromDate, toHashOrRef),
     )
 
     @ParameterizedTest
@@ -101,7 +104,7 @@ abstract class BaseVcsFacadeTest(
         fromDate: Date?,
         toHashOrRef: String,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             getCommits(testService.sshUrl(group, repository), fromHashOrRef, fromDate, toHashOrRef)
@@ -120,7 +123,7 @@ abstract class BaseVcsFacadeTest(
         fromDate: Date?,
         toHashOrRef: String,
         commitFilesLimit: Int?,
-        commitsWithFilesFile: String
+        commitsWithFilesFile: String,
     ) = Assertions.assertIterableEquals(
         testService.getCommitsWithFiles(commitsWithFilesFile),
         getCommitsWithFiles(
@@ -128,8 +131,8 @@ abstract class BaseVcsFacadeTest(
             fromHashOrRef,
             fromDate,
             toHashOrRef,
-            commitFilesLimit
-        )
+            commitFilesLimit,
+        ),
     )
 
     @ParameterizedTest
@@ -141,7 +144,7 @@ abstract class BaseVcsFacadeTest(
         fromDate: Date?,
         toHashOrRef: String,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             getCommitsWithFiles(testService.sshUrl(group, repository), fromHashOrRef, fromDate, toHashOrRef, null)
@@ -157,10 +160,10 @@ abstract class BaseVcsFacadeTest(
         group: String,
         repository: String,
         hashOrRef: String,
-        commitFile: String
+        commitFile: String,
     ) = Assertions.assertEquals(
         testService.getCommit(commitFile),
-        getCommit(testService.sshUrl(group, repository), hashOrRef)
+        getCommit(testService.sshUrl(group, repository), hashOrRef),
     )
 
     @ParameterizedTest
@@ -169,7 +172,7 @@ abstract class BaseVcsFacadeTest(
         group: String,
         repository: String,
         hashOrRef: String,
-        exceptionClass: Class<out Throwable>
+        exceptionClass: Class<out Throwable>,
     ) {
         Assertions.assertThrows(exceptionClass) {
             getCommit(testService.sshUrl(group, repository), hashOrRef)
@@ -183,10 +186,10 @@ abstract class BaseVcsFacadeTest(
         repository: String,
         hashOrRef: String,
         commitFilesLimit: Int?,
-        commitWithFilesFile: String
+        commitWithFilesFile: String,
     ) = Assertions.assertEquals(
         testService.getCommitWithFiles(commitWithFilesFile),
-        getCommitWithFiles(testService.sshUrl(group, repository), hashOrRef, commitFilesLimit)
+        getCommitWithFiles(testService.sshUrl(group, repository), hashOrRef, commitFilesLimit),
     )
 
     @ParameterizedTest
@@ -195,7 +198,7 @@ abstract class BaseVcsFacadeTest(
         group: String,
         repository: String,
         hashOrRef: String,
-        exceptionClass: Class<out Throwable>
+        exceptionClass: Class<out Throwable>,
     ) {
         Assertions.assertThrows(exceptionClass) {
             getCommitWithFiles(testService.sshUrl(group, repository), hashOrRef, null)
@@ -210,10 +213,10 @@ abstract class BaseVcsFacadeTest(
         fromHashOrRef: String?,
         fromDate: Date?,
         toHashOrRef: String,
-        issuesFromCommitsFile: String
+        issuesFromCommitsFile: String,
     ) = Assertions.assertEquals(
         testService.getIssuesFromCommits(issuesFromCommitsFile),
-        getIssuesFromCommits(testService.sshUrl(group, repository), fromHashOrRef, fromDate, toHashOrRef)
+        getIssuesFromCommits(testService.sshUrl(group, repository), fromHashOrRef, fromDate, toHashOrRef),
     )
 
     @ParameterizedTest
@@ -225,7 +228,7 @@ abstract class BaseVcsFacadeTest(
         fromDate: Date?,
         toHashOrRef: String,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             getIssuesFromCommits(testService.sshUrl(group, repository), fromHashOrRef, fromDate, toHashOrRef)
@@ -241,10 +244,10 @@ abstract class BaseVcsFacadeTest(
         group: String,
         repository: String,
         names: Set<String>?,
-        getTagsFile: String
+        getTagsFile: String,
     ) = Assertions.assertEquals(
         testService.getTags(getTagsFile),
-        getTags(testService.sshUrl(group, repository), names)
+        getTags(testService.sshUrl(group, repository), names),
     )
 
     @Test
@@ -255,25 +258,36 @@ abstract class BaseVcsFacadeTest(
     }
 
     @Test
-    fun getTagTest() = Assertions.assertEquals(
-        testService.getTag("tag.json"),
-        getTag(testService.sshUrl(GROUP, REPOSITORY_2), "v1.0")
-    )
+    fun getTagTest() =
+        Assertions.assertEquals(
+            testService.getTag("tag.json"),
+            getTag(testService.sshUrl(GROUP, REPOSITORY_2), "v1.0"),
+        )
 
     @ParameterizedTest
     @MethodSource("createTagFailsArguments")
-    fun createTagFailsTest(group: String, repository: String, hashOrRef: String, exceptionClass: Class<out Throwable>) {
+    fun createTagFailsTest(
+        group: String,
+        repository: String,
+        hashOrRef: String,
+        exceptionClass: Class<out Throwable>,
+    ) {
         Assertions.assertThrows(exceptionClass) {
             createTag(
                 testService.sshUrl(group, repository),
-                CreateTag("tag", hashOrRef, "createTagFailsTest")
+                CreateTag("tag", hashOrRef, "createTagFailsTest"),
             )
         }
     }
 
     @ParameterizedTest
     @MethodSource("getTagFailsArguments")
-    fun getTagFailsTest(group: String, repository: String, name: String, exceptionClass: Class<out Throwable>) {
+    fun getTagFailsTest(
+        group: String,
+        repository: String,
+        name: String,
+        exceptionClass: Class<out Throwable>,
+    ) {
         Assertions.assertThrows(exceptionClass) {
             getTag(testService.sshUrl(group, repository), name)
         }
@@ -281,41 +295,47 @@ abstract class BaseVcsFacadeTest(
 
     @ParameterizedTest
     @MethodSource("getTagFailsArguments")
-    fun deleteTagFailsTest(group: String, repository: String, name: String, exceptionClass: Class<out Throwable>) {
+    fun deleteTagFailsTest(
+        group: String,
+        repository: String,
+        name: String,
+        exceptionClass: Class<out Throwable>,
+    ) {
         Assertions.assertThrows(exceptionClass) {
             deleteTag(testService.sshUrl(group, repository), name)
         }
     }
 
     @Test
-    fun searchIssueInRangesTest() = Assertions.assertEquals(
-        testService.getSearchIssueInRangesResponse("search-issue-in-ranges.json"),
-        searchIssuesInRanges(
-            SearchIssuesInRangesRequest(
-                setOf("ISSUE-1", "ISSUE-3"),
-                setOf(
-                    RepositoryRange(
-                        testService.sshUrl(GROUP, REPOSITORY_2),
-                        null,
-                        null,
-                        "master"
+    fun searchIssueInRangesTest() =
+        Assertions.assertEquals(
+            testService.getSearchIssueInRangesResponse("search-issue-in-ranges.json"),
+            searchIssuesInRanges(
+                SearchIssuesInRangesRequest(
+                    setOf("ISSUE-1", "ISSUE-3"),
+                    setOf(
+                        RepositoryRange(
+                            testService.sshUrl(GROUP, REPOSITORY_2),
+                            null,
+                            null,
+                            "master",
+                        ),
+                        RepositoryRange(
+                            testService.sshUrl(GROUP, REPOSITORY_2),
+                            "7df7b682b6be1dd1e3c81ef776d5d6da44ac8ee1",
+                            null,
+                            "v1.0.1",
+                        ),
+                        RepositoryRange(
+                            testService.sshUrl(GROUP, REPOSITORY_2),
+                            "v1.0",
+                            null,
+                            "feature/ISSUE-4",
+                        ),
                     ),
-                    RepositoryRange(
-                        testService.sshUrl(GROUP, REPOSITORY_2),
-                        "7df7b682b6be1dd1e3c81ef776d5d6da44ac8ee1",
-                        null,
-                        "v1.0.1"
-                    ),
-                    RepositoryRange(
-                        testService.sshUrl(GROUP, REPOSITORY_2),
-                        "v1.0",
-                        null,
-                        "feature/ISSUE-4"
-                    )
-                )
-            )
+                ),
+            ),
         )
-    )
 
     @ParameterizedTest
     @MethodSource("getCommitsFailsArguments")
@@ -326,7 +346,7 @@ abstract class BaseVcsFacadeTest(
         fromDate: Date?,
         toHashOrRef: String,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             searchIssuesInRanges(
@@ -337,10 +357,10 @@ abstract class BaseVcsFacadeTest(
                             testService.sshUrl(group, repository),
                             fromHashOrRef,
                             fromDate,
-                            toHashOrRef
-                        )
-                    )
-                )
+                            toHashOrRef,
+                        ),
+                    ),
+                ),
             )
         }
         if (exceptionMessage != null) {
@@ -353,7 +373,7 @@ abstract class BaseVcsFacadeTest(
     fun searchIssueInRangesFailsTest2(
         issueKeys: Set<String>,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(ArgumentsNotCompatibleException::class.java) {
             searchIssuesInRanges(
@@ -364,22 +384,22 @@ abstract class BaseVcsFacadeTest(
                             testService.sshUrl(GROUP, REPOSITORY_2),
                             null,
                             null,
-                            "master"
+                            "master",
                         ),
                         RepositoryRange(
                             testService.sshUrl(GROUP, REPOSITORY_2),
                             "7df7b682b6be1dd1e3c81ef776d5d6da44ac8ee1",
                             null,
-                            "v1.0.1"
+                            "v1.0.1",
                         ),
                         RepositoryRange(
                             testService.sshUrl(GROUP, REPOSITORY_2),
                             "v1.0",
                             null,
-                            "feature/ISSUE-4"
-                        )
-                    )
-                )
+                            "feature/ISSUE-4",
+                        ),
+                    ),
+                ),
             )
         }
         if (exceptionMessage != null) {
@@ -389,7 +409,10 @@ abstract class BaseVcsFacadeTest(
 
     @ParameterizedTest
     @MethodSource("findByIssueKeysArguments")
-    fun findByIssueKeysTest(issueKeys: Set<String>, searchSummaryFile: String) = Assertions.assertEquals(
+    fun findByIssueKeysTest(
+        issueKeys: Set<String>,
+        searchSummaryFile: String,
+    ) = Assertions.assertEquals(
         testService.getSearchSummary(searchSummaryFile),
         findByIssueKeys(issueKeys).let { searchSummary ->
             SearchSummary(
@@ -399,11 +422,13 @@ abstract class BaseVcsFacadeTest(
                     SearchSummary.SearchPullRequestsSummary(
                         searchSummary.pullRequests.size,
                         Date(1698062284000L),
-                        searchSummary.pullRequests.status
+                        searchSummary.pullRequests.status,
                     )
-                } else searchSummary.pullRequests
+                } else {
+                    searchSummary.pullRequests
+                },
             )
-        }
+        },
     )
 
     @ParameterizedTest
@@ -411,7 +436,7 @@ abstract class BaseVcsFacadeTest(
     fun findByIssueKeysFailsTest(
         issueKeys: Set<String>,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             findByIssueKeys(issueKeys)
@@ -423,9 +448,12 @@ abstract class BaseVcsFacadeTest(
 
     @ParameterizedTest
     @MethodSource("findBranchesByIssueKeysArguments")
-    fun findBranchesByIssueKeysTest(issueKeys: Set<String>, branchesByIssueKeyFile: String) = Assertions.assertEquals(
+    fun findBranchesByIssueKeysTest(
+        issueKeys: Set<String>,
+        branchesByIssueKeyFile: String,
+    ) = Assertions.assertEquals(
         testService.getBranches(branchesByIssueKeyFile),
-        findBranchesByIssueKeys(issueKeys)
+        findBranchesByIssueKeys(issueKeys),
     )
 
     @ParameterizedTest
@@ -433,7 +461,7 @@ abstract class BaseVcsFacadeTest(
     fun findBranchesByIssueKeysFailsTest(
         issueKeys: Set<String>,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             findBranchesByIssueKeys(issueKeys)
@@ -445,15 +473,17 @@ abstract class BaseVcsFacadeTest(
 
     @ParameterizedTest
     @MethodSource("findCommitsByIssueKeysArguments")
-    fun findCommitsByIssueKeysTest(issueKeys: Set<String>, commitsByIssueKeyFile: String) =
-        Assertions.assertEquals(testService.getCommits(commitsByIssueKeyFile), findCommitsByIssueKeys(issueKeys))
+    fun findCommitsByIssueKeysTest(
+        issueKeys: Set<String>,
+        commitsByIssueKeyFile: String,
+    ) = Assertions.assertEquals(testService.getCommits(commitsByIssueKeyFile), findCommitsByIssueKeys(issueKeys))
 
     @ParameterizedTest
     @MethodSource("findByIssueKeysFailsArguments")
     fun findCommitsByIssueKeysFailsTest(
         issueKeys: Set<String>,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             findCommitsByIssueKeys(issueKeys)
@@ -468,10 +498,10 @@ abstract class BaseVcsFacadeTest(
     fun findCommitsWithFilesByIssueKeysTest(
         issueKeys: Set<String>,
         commitFilesLimit: Int?,
-        commitsWithFilesByIssueKeyFile: String
+        commitsWithFilesByIssueKeyFile: String,
     ) = Assertions.assertEquals(
         testService.getCommitsWithFiles(commitsWithFilesByIssueKeyFile),
-        findCommitsWithFilesByIssueKeys(issueKeys, commitFilesLimit)
+        findCommitsWithFilesByIssueKeys(issueKeys, commitFilesLimit),
     )
 
     @ParameterizedTest
@@ -479,7 +509,7 @@ abstract class BaseVcsFacadeTest(
     fun findCommitsWithFilesByIssueKeysFailsTest(
         issueKeys: Set<String>,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             findCommitsWithFilesByIssueKeys(issueKeys, null)
@@ -491,33 +521,36 @@ abstract class BaseVcsFacadeTest(
 
     @ParameterizedTest
     @MethodSource("findPullRequestsByIssueKeysArguments")
-    fun findPullRequestsByIssueKeysTest(issueKeys: Set<String>, pullRequestsByIssueKeyFile: String) =
-        Assertions.assertEquals(
-            testService.getPullRequests(pullRequestsByIssueKeyFile),
-            findPullRequestsByIssueKeys(issueKeys).map { pullRequest ->
-                PullRequest(
-                    pullRequest.index, pullRequest.title,
-                    pullRequest.description,
-                    pullRequest.author,
-                    pullRequest.source,
-                    pullRequest.target,
-                    pullRequest.assignees,
-                    pullRequest.reviewers,
-                    pullRequest.status,
-                    Date(1698062284000L),
-                    Date(1698062284000L),
-                    pullRequest.link,
-                    pullRequest.repository
-                )
-            }
-        )
+    fun findPullRequestsByIssueKeysTest(
+        issueKeys: Set<String>,
+        pullRequestsByIssueKeyFile: String,
+    ) = Assertions.assertEquals(
+        testService.getPullRequests(pullRequestsByIssueKeyFile),
+        findPullRequestsByIssueKeys(issueKeys).map { pullRequest ->
+            PullRequest(
+                pullRequest.index,
+                pullRequest.title,
+                pullRequest.description,
+                pullRequest.author,
+                pullRequest.source,
+                pullRequest.target,
+                pullRequest.assignees,
+                pullRequest.reviewers,
+                pullRequest.status,
+                Date(1698062284000L),
+                Date(1698062284000L),
+                pullRequest.link,
+                pullRequest.repository,
+            )
+        },
+    )
 
     @ParameterizedTest
     @MethodSource("findByIssueKeysFailsArguments")
     fun findPullRequestsByIssueKeysFailsTest(
         issueKeys: Set<String>,
         exceptionClass: Class<out Throwable>,
-        exceptionMessage: String?
+        exceptionMessage: String?,
     ) {
         val exception = Assertions.assertThrows(exceptionClass) {
             findPullRequestsByIssueKeys(issueKeys)
@@ -527,35 +560,63 @@ abstract class BaseVcsFacadeTest(
         }
     }
 
-    protected abstract fun createPullRequest(sshUrl: String, createPullRequest: CreatePullRequest): PullRequest
+    protected abstract fun createPullRequest(
+        sshUrl: String,
+        createPullRequest: CreatePullRequest,
+    ): PullRequest
 
     protected abstract fun getCommits(
-        sshUrl: String, fromHashOrRef: String?, fromDate: Date?, toHashOrRef: String
+        sshUrl: String,
+        fromHashOrRef: String?,
+        fromDate: Date?,
+        toHashOrRef: String,
     ): List<Commit>
 
     protected abstract fun getCommitsWithFiles(
-        sshUrl: String, fromHashOrRef: String?, fromDate: Date?, toHashOrRef: String, commitFilesLimit: Int?
+        sshUrl: String,
+        fromHashOrRef: String?,
+        fromDate: Date?,
+        toHashOrRef: String,
+        commitFilesLimit: Int?,
     ): List<CommitWithFiles>
 
-    protected abstract fun getCommit(sshUrl: String, hashOrRef: String): Commit
+    protected abstract fun getCommit(
+        sshUrl: String,
+        hashOrRef: String,
+    ): Commit
 
     protected abstract fun getCommitWithFiles(
         sshUrl: String,
         hashOrRef: String,
-        commitFilesLimit: Int?
+        commitFilesLimit: Int?,
     ): CommitWithFiles
 
     protected abstract fun getIssuesFromCommits(
-        sshUrl: String, fromHashOrRef: String?, fromDate: Date?, toHashOrRef: String
+        sshUrl: String,
+        fromHashOrRef: String?,
+        fromDate: Date?,
+        toHashOrRef: String,
     ): List<String>
 
-    protected abstract fun getTags(sshUrl: String, names: Set<String>?): List<Tag>
+    protected abstract fun getTags(
+        sshUrl: String,
+        names: Set<String>?,
+    ): List<Tag>
 
-    protected abstract fun createTag(sshUrl: String, createTag: CreateTag): Tag
+    protected abstract fun createTag(
+        sshUrl: String,
+        createTag: CreateTag,
+    ): Tag
 
-    protected abstract fun getTag(sshUrl: String, name: String): Tag
+    protected abstract fun getTag(
+        sshUrl: String,
+        name: String,
+    ): Tag
 
-    protected abstract fun deleteTag(sshUrl: String, name: String)
+    protected abstract fun deleteTag(
+        sshUrl: String,
+        name: String,
+    )
 
     protected abstract fun searchIssuesInRanges(searchRequest: SearchIssuesInRangesRequest): SearchIssueInRangesResponse
 
@@ -567,11 +628,10 @@ abstract class BaseVcsFacadeTest(
 
     protected abstract fun findCommitsWithFilesByIssueKeys(
         issueKeys: Set<String>,
-        commitFilesLimit: Int?
+        commitFilesLimit: Int?,
     ): List<CommitWithFiles>
 
     protected abstract fun findPullRequestsByIssueKeys(issueKeys: Set<String>): List<PullRequest>
-
 
     companion object {
         const val BITBUCKET_USER = "admin"
@@ -584,391 +644,417 @@ abstract class BaseVcsFacadeTest(
         const val REPOSITORY = "repository"
         const val REPOSITORY_2 = "repository-2"
 
-        //<editor-fold defaultstate="collapsed" desc="test parameters">
+        // <editor-fold defaultstate="collapsed" desc="test parameters">
         @JvmStatic
-        private fun createPullRequestFailsArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                "absent-repository",
-                CreatePullRequest(
-                    "branch16", "master", "Test PR title 2", "Test PR description 2"
+        private fun createPullRequestFailsArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    "absent-repository",
+                    CreatePullRequest(
+                        "branch16",
+                        "master",
+                        "Test PR title 2",
+                        "Test PR description 2",
+                    ),
+                    NotFoundException::class.java,
                 ),
-                NotFoundException::class.java
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                CreatePullRequest(
-                    "absent-ref", "master", "Test PR title 3", "Test PR description 3"
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    CreatePullRequest(
+                        "absent-ref",
+                        "master",
+                        "Test PR title 3",
+                        "Test PR description 3",
+                    ),
+                    NotFoundException::class.java,
                 ),
-                NotFoundException::class.java
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                CreatePullRequest(
-                    "branch16", "absent-ref", "Test PR title 4", "Test PR description 4"
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    CreatePullRequest(
+                        "branch16",
+                        "absent-ref",
+                        "Test PR title 4",
+                        "Test PR description 4",
+                    ),
+                    NotFoundException::class.java,
                 ),
-                NotFoundException::class.java
             )
-        )
 
         @JvmStatic
-        private fun getCommitsArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                null,
-                Date(1698062284000L),
-                "5fb773dbe6472a87632b1c68ea771decdcd20f1e",
-                "commits.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                "c79babff3c1405618214eba90398c685ac4c0349",
-                null,
-                "5fb773dbe6472a87632b1c68ea771decdcd20f1e",
-                "commits-2.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                "branch8",
-                null,
-                "branch6",
-                "commits-3.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                null,
-                null,
-                "master",
-                "commits-4.json"
+        private fun getCommitsArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    null,
+                    Date(1698062284000L),
+                    "5fb773dbe6472a87632b1c68ea771decdcd20f1e",
+                    "commits.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    "c79babff3c1405618214eba90398c685ac4c0349",
+                    null,
+                    "5fb773dbe6472a87632b1c68ea771decdcd20f1e",
+                    "commits-2.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    "branch8",
+                    null,
+                    "branch6",
+                    "commits-3.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    null,
+                    null,
+                    "master",
+                    "commits-4.json",
+                ),
             )
-        )
 
         @JvmStatic
-        private fun getCommitsFailsArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                "master",
-                Date(),
-                "master",
-                ArgumentsNotCompatibleException::class.java,
-                "'hashOrRef' and 'date' can not be used together"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                "9c8daf84e7ed6ea1d32f654362131e26dbf37440",
-                null,
-                "a933dc6b4fe8e8f66856b4cb9da7f4bf8ad0e017",
-                NotFoundException::class.java,
-                "Cannot find commit '9c8daf84e7ed6ea1d32f654362131e26dbf37440' in commit graph for commit 'a933dc6b4fe8e8f66856b4cb9da7f4bf8ad0e017' in 'test:repository'"
-            ),
-            Arguments.of(
-                GROUP,
-                "absent-repository",
-                null,
-                null,
-                "master",
-                NotFoundException::class.java,
-                null
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY,
-                null,
-                null,
-                "absent-ref",
-                NotFoundException::class.java,
-                null
+        private fun getCommitsFailsArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    "master",
+                    Date(),
+                    "master",
+                    ArgumentsNotCompatibleException::class.java,
+                    "'hashOrRef' and 'date' can not be used together",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    "9c8daf84e7ed6ea1d32f654362131e26dbf37440",
+                    null,
+                    "a933dc6b4fe8e8f66856b4cb9da7f4bf8ad0e017",
+                    NotFoundException::class.java,
+                    "Cannot find commit '9c8daf84e7ed6ea1d32f654362131e26dbf37440' in commit graph for commit 'a933dc6b4fe8e8f66856b4cb9da7f4bf8ad0e017' in 'test:repository'",
+                ),
+                Arguments.of(
+                    GROUP,
+                    "absent-repository",
+                    null,
+                    null,
+                    "master",
+                    NotFoundException::class.java,
+                    null,
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY,
+                    null,
+                    null,
+                    "absent-ref",
+                    NotFoundException::class.java,
+                    null,
+                ),
             )
-        )
 
         @JvmStatic
-        private fun getCommitsWithFilesArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                null,
-                null,
-                "master",
-                null,
-                "commits-with-files.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                null,
-                null,
-                "master",
-                1,
-                "commits-with-files-2.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "7df7b682b6be1dd1e3c81ef776d5d6da44ac8ee1",
-                null,
-                "v1.0.1",
-                -1,
-                "commits-with-files-3.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "v1.0",
-                null,
-                "feature/ISSUE-4",
-                null,
-                "commits-with-files-4.json"
+        private fun getCommitsWithFilesArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    null,
+                    null,
+                    "master",
+                    null,
+                    "commits-with-files.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    null,
+                    null,
+                    "master",
+                    1,
+                    "commits-with-files-2.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "7df7b682b6be1dd1e3c81ef776d5d6da44ac8ee1",
+                    null,
+                    "v1.0.1",
+                    -1,
+                    "commits-with-files-3.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "v1.0",
+                    null,
+                    "feature/ISSUE-4",
+                    null,
+                    "commits-with-files-4.json",
+                ),
             )
-        )
 
         @JvmStatic
-        private fun getCommitArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "fa20861b90c54efbffeb48837f4044bc23b55238",
-                "commit.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "bugfix/ISSUE-3",
-                "commit-2.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "v1.0",
-                "commit-3.json"
-            ),
-        )
-
-        @JvmStatic
-        private fun getCommitFailsArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "invalid-commit-hash",
-                NotFoundException::class.java
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "0123456789abcdef0123456789abcdef01234567",
-                NotFoundException::class.java
-            ),
-            Arguments.of(
-                GROUP,
-                "absent-repository",
-                "0123456789abcdef0123456789abcdef01234567",
-                NotFoundException::class.java
-            ),
-        )
-
-        @JvmStatic
-        private fun getCommitWithFilesArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "fa20861b90c54efbffeb48837f4044bc23b55238",
-                1,
-                "commit-with-files.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "bugfix/ISSUE-3",
-                -1,
-                "commit-with-files-2.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "v1.0",
-                null,
-                "commit-with-files-3.json"
-            ),
-        )
-
-        @JvmStatic
-        private fun getTagsArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                null,
-                "tags.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                setOf("v1.0"),
-                "tags-2.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                emptySet<String>(),
-                "tags-3.json"
+        private fun getCommitArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "fa20861b90c54efbffeb48837f4044bc23b55238",
+                    "commit.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "bugfix/ISSUE-3",
+                    "commit-2.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "v1.0",
+                    "commit-3.json",
+                ),
             )
-        )
 
         @JvmStatic
-        private fun createTagFailsArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "absent-hash-or-ref",
-                NotFoundException::class.java
-            ),
-            Arguments.of(
-                GROUP,
-                "absent-repository",
-                "absent-hash-or-ref",
-                NotFoundException::class.java
-            ),
-        )
-
-        @JvmStatic
-        private fun getTagFailsArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "absent-tag",
-                NotFoundException::class.java
-            ),
-            Arguments.of(
-                GROUP,
-                "absent-repository",
-                "absent-tag",
-                NotFoundException::class.java
-            ),
-        )
-
-        @JvmStatic
-        private fun getIssuesFromCommitsArguments() = Stream.of(
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                null,
-                null,
-                "master",
-                "issues-from-commits.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "7df7b682b6be1dd1e3c81ef776d5d6da44ac8ee1",
-                null,
-                "v1.0.1",
-                "issues-from-commits-2.json"
-            ),
-            Arguments.of(
-                GROUP,
-                REPOSITORY_2,
-                "v1.0",
-                null,
-                "feature/ISSUE-4",
-                "issues-from-commits-3.json"
+        private fun getCommitFailsArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "invalid-commit-hash",
+                    NotFoundException::class.java,
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "0123456789abcdef0123456789abcdef01234567",
+                    NotFoundException::class.java,
+                ),
+                Arguments.of(
+                    GROUP,
+                    "absent-repository",
+                    "0123456789abcdef0123456789abcdef01234567",
+                    NotFoundException::class.java,
+                ),
             )
-        )
 
         @JvmStatic
-        private fun findByIssueKeysArguments() = Stream.of(
-            Arguments.of(setOf("ISSUE-1"), "search-summary.json"),
-            Arguments.of(setOf("ISSUE-2"), "search-summary-2.json"),
-            Arguments.of(setOf("ISSUE-3"), "search-summary-3.json"),
-            Arguments.of(setOf("ISSUE-4"), "search-summary-4.json"),
-            Arguments.of(setOf("ISSUE-5"), "search-summary-5.json"),
-            Arguments.of(setOf("ISSUE-6"), "search-summary-6.json"),
-            Arguments.of(setOf("ISSUE-7"), "search-summary-7.json"),
-            Arguments.of(
-                setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
-                "search-summary-8.json"
+        private fun getCommitWithFilesArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "fa20861b90c54efbffeb48837f4044bc23b55238",
+                    1,
+                    "commit-with-files.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "bugfix/ISSUE-3",
+                    -1,
+                    "commit-with-files-2.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "v1.0",
+                    null,
+                    "commit-with-files-3.json",
+                ),
             )
-        )
 
         @JvmStatic
-        private fun findByIssueKeysFailsArguments() = Stream.of(
-            Arguments.of(
-                setOf("ISSUE"),
-                ArgumentsNotCompatibleException::class.java,
-                "Invalid issue keys: 'ISSUE'"
-            ),
-            Arguments.of(
-                setOf("ISSUE-1", "ISSUE-2A", " ISSUE-3", "ISSUE+4", "0ISSUE-5"),
-                ArgumentsNotCompatibleException::class.java,
-                "Invalid issue keys: ' ISSUE-3', '0ISSUE-5', 'ISSUE+4', 'ISSUE-2A'"
+        private fun getTagsArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    null,
+                    "tags.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    setOf("v1.0"),
+                    "tags-2.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    emptySet<String>(),
+                    "tags-3.json",
+                ),
             )
-        )
 
         @JvmStatic
-        private fun findBranchesByIssueKeysArguments() = Stream.of(
-            Arguments.of(setOf("ISSUE-1"), "branches-by-issue-keys.json"),
-            Arguments.of(setOf("ISSUE-2"), "branches-by-issue-keys-2.json"),
-            Arguments.of(setOf("ISSUE-3"), "branches-by-issue-keys-3.json"),
-            Arguments.of(setOf("ISSUE-4"), "branches-by-issue-keys-4.json"),
-            Arguments.of(setOf("ISSUE-5"), "branches-by-issue-keys-5.json"),
-            Arguments.of(setOf("ISSUE-6"), "branches-by-issue-keys-6.json"),
-            Arguments.of(setOf("ISSUE-7"), "branches-by-issue-keys-7.json"),
-            Arguments.of(
-                setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
-                "branches-by-issue-keys-8.json"
+        private fun createTagFailsArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "absent-hash-or-ref",
+                    NotFoundException::class.java,
+                ),
+                Arguments.of(
+                    GROUP,
+                    "absent-repository",
+                    "absent-hash-or-ref",
+                    NotFoundException::class.java,
+                ),
             )
-        )
 
         @JvmStatic
-        private fun findCommitsByIssueKeysArguments() = Stream.of(
-            Arguments.of(setOf("ISSUE-1"), "commits-by-issue-keys.json"),
-            Arguments.of(setOf("ISSUE-2"), "commits-by-issue-keys-2.json"),
-            Arguments.of(setOf("ISSUE-3"), "commits-by-issue-keys-3.json"),
-            Arguments.of(setOf("ISSUE-4"), "commits-by-issue-keys-4.json"),
-            Arguments.of(setOf("ISSUE-5"), "commits-by-issue-keys-5.json"),
-            Arguments.of(setOf("ISSUE-6"), "commits-by-issue-keys-6.json"),
-            Arguments.of(setOf("ISSUE-7"), "commits-by-issue-keys-7.json"),
-            Arguments.of(
-                setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
-                "commits-by-issue-keys-8.json"
+        private fun getTagFailsArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "absent-tag",
+                    NotFoundException::class.java,
+                ),
+                Arguments.of(
+                    GROUP,
+                    "absent-repository",
+                    "absent-tag",
+                    NotFoundException::class.java,
+                ),
             )
-        )
 
         @JvmStatic
-        private fun findCommitsWithFilesByIssueKeysArguments() = Stream.of(
-            Arguments.of(setOf("ISSUE-1"), null, "commits-with-files-by-issue-keys.json"),
-            Arguments.of(setOf("ISSUE-2"), -1, "commits-with-files-by-issue-keys-2.json"),
-            Arguments.of(setOf("ISSUE-3"), 1, "commits-with-files-by-issue-keys-3.json"),
-            Arguments.of(setOf("ISSUE-4"), 2, "commits-with-files-by-issue-keys-4.json"),
-            Arguments.of(setOf("ISSUE-5"), 0, "commits-with-files-by-issue-keys-5.json"),
-            Arguments.of(setOf("ISSUE-6"), 0, "commits-with-files-by-issue-keys-6.json"),
-            Arguments.of(setOf("ISSUE-7"), 0, "commits-with-files-by-issue-keys-7.json"),
-            Arguments.of(
-                setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
-                0,
-                "commits-with-files-by-issue-keys-8.json"
+        private fun getIssuesFromCommitsArguments() =
+            Stream.of(
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    null,
+                    null,
+                    "master",
+                    "issues-from-commits.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "7df7b682b6be1dd1e3c81ef776d5d6da44ac8ee1",
+                    null,
+                    "v1.0.1",
+                    "issues-from-commits-2.json",
+                ),
+                Arguments.of(
+                    GROUP,
+                    REPOSITORY_2,
+                    "v1.0",
+                    null,
+                    "feature/ISSUE-4",
+                    "issues-from-commits-3.json",
+                ),
             )
-        )
 
         @JvmStatic
-        private fun findPullRequestsByIssueKeysArguments() = Stream.of(
-            Arguments.of(setOf("ISSUE-1"), "pull-requests-by-issue-keys.json"),
-            Arguments.of(setOf("ISSUE-2"), "pull-requests-by-issue-keys-2.json"),
-            Arguments.of(setOf("ISSUE-3"), "pull-requests-by-issue-keys-3.json"),
-            Arguments.of(setOf("ISSUE-4"), "pull-requests-by-issue-keys-4.json"),
-            Arguments.of(setOf("ISSUE-5"), "pull-requests-by-issue-keys-5.json"),
-            Arguments.of(setOf("ISSUE-6"), "pull-requests-by-issue-keys-6.json"),
-            Arguments.of(setOf("ISSUE-7"), "pull-requests-by-issue-keys-7.json"),
-            Arguments.of(
-                setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
-                "pull-requests-by-issue-keys-8.json"
+        private fun findByIssueKeysArguments() =
+            Stream.of(
+                Arguments.of(setOf("ISSUE-1"), "search-summary.json"),
+                Arguments.of(setOf("ISSUE-2"), "search-summary-2.json"),
+                Arguments.of(setOf("ISSUE-3"), "search-summary-3.json"),
+                Arguments.of(setOf("ISSUE-4"), "search-summary-4.json"),
+                Arguments.of(setOf("ISSUE-5"), "search-summary-5.json"),
+                Arguments.of(setOf("ISSUE-6"), "search-summary-6.json"),
+                Arguments.of(setOf("ISSUE-7"), "search-summary-7.json"),
+                Arguments.of(
+                    setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
+                    "search-summary-8.json",
+                ),
             )
-        )
-        //</editor-fold>
+
+        @JvmStatic
+        private fun findByIssueKeysFailsArguments() =
+            Stream.of(
+                Arguments.of(
+                    setOf("ISSUE"),
+                    ArgumentsNotCompatibleException::class.java,
+                    "Invalid issue keys: 'ISSUE'",
+                ),
+                Arguments.of(
+                    setOf("ISSUE-1", "ISSUE-2A", " ISSUE-3", "ISSUE+4", "0ISSUE-5"),
+                    ArgumentsNotCompatibleException::class.java,
+                    "Invalid issue keys: ' ISSUE-3', '0ISSUE-5', 'ISSUE+4', 'ISSUE-2A'",
+                ),
+            )
+
+        @JvmStatic
+        private fun findBranchesByIssueKeysArguments() =
+            Stream.of(
+                Arguments.of(setOf("ISSUE-1"), "branches-by-issue-keys.json"),
+                Arguments.of(setOf("ISSUE-2"), "branches-by-issue-keys-2.json"),
+                Arguments.of(setOf("ISSUE-3"), "branches-by-issue-keys-3.json"),
+                Arguments.of(setOf("ISSUE-4"), "branches-by-issue-keys-4.json"),
+                Arguments.of(setOf("ISSUE-5"), "branches-by-issue-keys-5.json"),
+                Arguments.of(setOf("ISSUE-6"), "branches-by-issue-keys-6.json"),
+                Arguments.of(setOf("ISSUE-7"), "branches-by-issue-keys-7.json"),
+                Arguments.of(
+                    setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
+                    "branches-by-issue-keys-8.json",
+                ),
+            )
+
+        @JvmStatic
+        private fun findCommitsByIssueKeysArguments() =
+            Stream.of(
+                Arguments.of(setOf("ISSUE-1"), "commits-by-issue-keys.json"),
+                Arguments.of(setOf("ISSUE-2"), "commits-by-issue-keys-2.json"),
+                Arguments.of(setOf("ISSUE-3"), "commits-by-issue-keys-3.json"),
+                Arguments.of(setOf("ISSUE-4"), "commits-by-issue-keys-4.json"),
+                Arguments.of(setOf("ISSUE-5"), "commits-by-issue-keys-5.json"),
+                Arguments.of(setOf("ISSUE-6"), "commits-by-issue-keys-6.json"),
+                Arguments.of(setOf("ISSUE-7"), "commits-by-issue-keys-7.json"),
+                Arguments.of(
+                    setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
+                    "commits-by-issue-keys-8.json",
+                ),
+            )
+
+        @JvmStatic
+        private fun findCommitsWithFilesByIssueKeysArguments() =
+            Stream.of(
+                Arguments.of(setOf("ISSUE-1"), null, "commits-with-files-by-issue-keys.json"),
+                Arguments.of(setOf("ISSUE-2"), -1, "commits-with-files-by-issue-keys-2.json"),
+                Arguments.of(setOf("ISSUE-3"), 1, "commits-with-files-by-issue-keys-3.json"),
+                Arguments.of(setOf("ISSUE-4"), 2, "commits-with-files-by-issue-keys-4.json"),
+                Arguments.of(setOf("ISSUE-5"), 0, "commits-with-files-by-issue-keys-5.json"),
+                Arguments.of(setOf("ISSUE-6"), 0, "commits-with-files-by-issue-keys-6.json"),
+                Arguments.of(setOf("ISSUE-7"), 0, "commits-with-files-by-issue-keys-7.json"),
+                Arguments.of(
+                    setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
+                    0,
+                    "commits-with-files-by-issue-keys-8.json",
+                ),
+            )
+
+        @JvmStatic
+        private fun findPullRequestsByIssueKeysArguments() =
+            Stream.of(
+                Arguments.of(setOf("ISSUE-1"), "pull-requests-by-issue-keys.json"),
+                Arguments.of(setOf("ISSUE-2"), "pull-requests-by-issue-keys-2.json"),
+                Arguments.of(setOf("ISSUE-3"), "pull-requests-by-issue-keys-3.json"),
+                Arguments.of(setOf("ISSUE-4"), "pull-requests-by-issue-keys-4.json"),
+                Arguments.of(setOf("ISSUE-5"), "pull-requests-by-issue-keys-5.json"),
+                Arguments.of(setOf("ISSUE-6"), "pull-requests-by-issue-keys-6.json"),
+                Arguments.of(setOf("ISSUE-7"), "pull-requests-by-issue-keys-7.json"),
+                Arguments.of(
+                    setOf("ISSUE-1", "ISSUE-2", "ISSUE-3", "ISSUE-4", "ISSUE-5", "ISSUE-6", "ISSUE-7"),
+                    "pull-requests-by-issue-keys-8.json",
+                ),
+            )
+        // </editor-fold>
     }
 }

--- a/test-common/src/main/kotlin/org/octopusden/octopus/vcsfacade/BaseVcsFacadeTestExtended.kt
+++ b/test-common/src/main/kotlin/org/octopusden/octopus/vcsfacade/BaseVcsFacadeTestExtended.kt
@@ -1,15 +1,16 @@
 package org.octopusden.octopus.vcsfacade
 
-import java.io.File
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.octopusden.octopus.infrastructure.common.test.TestClient
 import org.octopusden.octopus.vcsfacade.client.common.dto.CreateTag
+import java.io.File
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class BaseVcsFacadeTestExtended(
-    testService: TestService, testClient: TestClient
+    testService: TestService,
+    testClient: TestClient,
 ) : BaseVcsFacadeTest(testService, testClient) {
     @Test
     fun tagsTestScenario() {
@@ -18,26 +19,28 @@ abstract class BaseVcsFacadeTestExtended(
             testService.sshUrl(GROUP, repository),
             File.createTempFile("BaseVcsFacadeTest-", "-$GROUP-$repository").apply {
                 outputStream().use {
-                    BaseVcsFacadeTestExtended::class.java.classLoader.getResourceAsStream("$GROUP-$REPOSITORY_2.zip")!!
+                    BaseVcsFacadeTestExtended::class.java.classLoader
+                        .getResourceAsStream("$GROUP-$REPOSITORY_2.zip")!!
                         .copyTo(it)
                 }
-            }
+            },
         )
         createTag(
             testService.sshUrl(GROUP, repository),
-            CreateTag("test-0.1", "v1.0", "tagsTestScenario")
+            CreateTag("test-0.1", "v1.0", "tagsTestScenario"),
         )
         createTag(
             testService.sshUrl(GROUP, repository),
-            CreateTag("test-0.2", "d25d71af3afa700e91a1613c5ab4ec6b26a88ff7", "tagsTestScenario")
+            CreateTag("test-0.2", "d25d71af3afa700e91a1613c5ab4ec6b26a88ff7", "tagsTestScenario"),
         )
         createTag(
             testService.sshUrl(GROUP, repository),
-            CreateTag("test-0.3", "feature/ISSUE-4", "tagsTestScenario")
+            CreateTag("test-0.3", "feature/ISSUE-4", "tagsTestScenario"),
         )
         deleteTag(testService.sshUrl(GROUP, repository), "v1.0")
         Assertions.assertEquals(
-            testService.getTags("tags-scenario.json"), getTags(testService.sshUrl(GROUP, repository), null)
+            testService.getTags("tags-scenario.json"),
+            getTags(testService.sshUrl(GROUP, repository), null),
         )
     }
 }

--- a/test-common/src/main/kotlin/org/octopusden/octopus/vcsfacade/TestService.kt
+++ b/test-common/src/main/kotlin/org/octopusden/octopus/vcsfacade/TestService.kt
@@ -3,10 +3,6 @@ package org.octopusden.octopus.vcsfacade
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import java.net.HttpURLConnection
-import java.net.URI
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import org.octopusden.octopus.vcsfacade.client.common.dto.Branch
 import org.octopusden.octopus.vcsfacade.client.common.dto.Commit
 import org.octopusden.octopus.vcsfacade.client.common.dto.CommitWithFiles
@@ -19,16 +15,26 @@ import org.octopusden.octopus.vcsfacade.client.common.dto.SearchIssueInRangesRes
 import org.octopusden.octopus.vcsfacade.client.common.dto.SearchSummary
 import org.octopusden.octopus.vcsfacade.client.common.dto.Tag
 import org.octopusden.octopus.vcsfacade.client.common.dto.User
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 sealed class TestService(
     private val vcsFacadeHost: String,
-    protected val vcsHost: String
+    protected val vcsHost: String,
 ) {
     protected abstract val type: String
 
-    abstract fun sshUrl(group: String, repository: String): String
+    abstract fun sshUrl(
+        group: String,
+        repository: String,
+    ): String
 
-    fun scan(group: String, repository: String) {
+    fun scan(
+        group: String,
+        repository: String,
+    ) {
         val query = "sshUrl=${URLEncoder.encode(sshUrl(group, repository), StandardCharsets.UTF_8)}"
         val url = URI("http://$vcsFacadeHost/rest/api/1/indexer/scan?$query").toURL()
         with(url.openConnection() as HttpURLConnection) {
@@ -37,79 +43,107 @@ sealed class TestService(
                 throw RuntimeException("Unable to schedule '$group:$repository' scan")
             }
         }
-        Thread.sleep(10000) //vcs-facade.opensearch.index.scan.delay * 2
+        Thread.sleep(10000) // vcs-facade.opensearch.index.scan.delay * 2
     }
 
-    fun getCommits(resource: String): List<Commit> = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<List<Commit>>() {}
-    ).map { it.replaceHost(vcsHost) }
+    fun getCommits(resource: String): List<Commit> =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<List<Commit>>() {},
+            ).map { it.replaceHost(vcsHost) }
 
+    fun getCommitsWithFiles(resource: String): List<CommitWithFiles> =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<List<CommitWithFiles>>() {},
+            ).map { it.replaceHost(vcsHost) }
 
-    fun getCommitsWithFiles(resource: String): List<CommitWithFiles> = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<List<CommitWithFiles>>() {}
-    ).map { it.replaceHost(vcsHost) }
+    fun getCommit(resource: String): Commit =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<Commit>() {},
+            ).replaceHost(vcsHost)
 
-    fun getCommit(resource: String): Commit = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<Commit>() {}
-    ).replaceHost(vcsHost)
+    fun getCommitWithFiles(resource: String): CommitWithFiles =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<CommitWithFiles>() {},
+            ).replaceHost(vcsHost)
 
-    fun getCommitWithFiles(resource: String): CommitWithFiles = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<CommitWithFiles>() {}
-    ).replaceHost(vcsHost)
+    fun getIssuesFromCommits(resource: String): List<String> =
+        OBJECT_MAPPER.readValue(
+            TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+            object : TypeReference<List<String>>() {},
+        )
 
+    fun getTags(resource: String): List<Tag> =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<List<Tag>>() {},
+            ).map { it.replaceHost(vcsHost) }
 
-    fun getIssuesFromCommits(resource: String): List<String> = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<List<String>>() {}
-    )
+    fun getTag(resource: String): Tag =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<Tag>() {},
+            ).replaceHost(vcsHost)
 
-    fun getTags(resource: String): List<Tag> = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<List<Tag>>() {}
-    ).map { it.replaceHost(vcsHost) }
+    fun getSearchIssueInRangesResponse(resource: String): SearchIssueInRangesResponse =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<SearchIssueInRangesResponse>() {},
+            ).replaceHost(vcsHost)
 
-    fun getTag(resource: String): Tag = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<Tag>() {}
-    ).replaceHost(vcsHost)
+    fun getSearchSummary(resource: String): SearchSummary =
+        OBJECT_MAPPER.readValue(
+            TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+            object : TypeReference<SearchSummary>() {},
+        )
 
-    fun getSearchIssueInRangesResponse(resource: String): SearchIssueInRangesResponse = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<SearchIssueInRangesResponse>() {}
-    ).replaceHost(vcsHost)
+    fun getBranches(resource: String): List<Branch> =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<List<Branch>>() {},
+            ).map { it.replaceHost(vcsHost) }
 
-    fun getSearchSummary(resource: String): SearchSummary = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<SearchSummary>() {}
-    )
+    fun getPullRequests(resource: String): List<PullRequest> =
+        OBJECT_MAPPER
+            .readValue(
+                TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
+                object : TypeReference<List<PullRequest>>() {},
+            ).map { it.replaceHost(vcsHost) }
 
-    fun getBranches(resource: String): List<Branch> = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<List<Branch>>() {}
-    ).map { it.replaceHost(vcsHost) }
-
-    fun getPullRequests(resource: String): List<PullRequest> = OBJECT_MAPPER.readValue(
-        TestService::class.java.classLoader.getResourceAsStream("$type/$resource"),
-        object : TypeReference<List<PullRequest>>() {}
-    ).map { it.replaceHost(vcsHost) }
-
-    class Bitbucket(vcsFacadeHost: String, vcsHost: String) : TestService(vcsFacadeHost, vcsHost) {
+    class Bitbucket(
+        vcsFacadeHost: String,
+        vcsHost: String,
+    ) : TestService(vcsFacadeHost, vcsHost) {
         override val type = "bitbucket"
 
-        override fun sshUrl(group: String, repository: String) =
-            "ssh://git@$vcsHost/$group/$repository.git"
+        override fun sshUrl(
+            group: String,
+            repository: String,
+        ) = "ssh://git@$vcsHost/$group/$repository.git"
     }
 
-    class Gitea(vcsFacadeHost: String, vcsHost: String, private val useColon: Boolean = false) :
-        TestService(vcsFacadeHost, vcsHost) {
+    class Gitea(
+        vcsFacadeHost: String,
+        vcsHost: String,
+        private val useColon: Boolean = false,
+    ) : TestService(vcsFacadeHost, vcsHost) {
         override val type = "gitea"
 
-        override fun sshUrl(group: String, repository: String) =
-            "ssh://git@$vcsHost${if (useColon) ":" else "/"}$group/$repository.git"
+        override fun sshUrl(
+            group: String,
+            repository: String,
+        ) = "ssh://git@$vcsHost${if (useColon) ":" else "/"}$group/$repository.git"
     }
 
     companion object {
@@ -117,62 +151,85 @@ sealed class TestService(
 
         private fun String.replaceHost(to: String) = replace("@test.vcs-host@", to, false)
 
-        private fun User.replaceHost(to: String) = User(
-            name, avatar?.replaceHost(to)
-        )
+        private fun User.replaceHost(to: String) =
+            User(
+                name,
+                avatar?.replaceHost(to),
+            )
 
-        private fun Repository.replaceHost(to: String) = Repository(
-            sshUrl.replaceHost(to), link.replaceHost(to), avatar?.replaceHost(to)
-        )
+        private fun Repository.replaceHost(to: String) =
+            Repository(
+                sshUrl.replaceHost(to),
+                link.replaceHost(to),
+                avatar?.replaceHost(to),
+            )
 
-        private fun Commit.replaceHost(to: String) = Commit(
-            hash,
-            message,
-            date,
-            author.replaceHost(to),
-            parents,
-            link.replaceHost(to),
-            repository.replaceHost(to)
-        )
+        private fun Commit.replaceHost(to: String) =
+            Commit(
+                hash,
+                message,
+                date,
+                author.replaceHost(to),
+                parents,
+                link.replaceHost(to),
+                repository.replaceHost(to),
+            )
 
-        private fun FileChange.replaceHost(to: String) = FileChange(
-            type, path, link.replaceHost(to)
-        )
+        private fun FileChange.replaceHost(to: String) =
+            FileChange(
+                type,
+                path,
+                link.replaceHost(to),
+            )
 
-        private fun CommitWithFiles.replaceHost(to: String) = CommitWithFiles(
-            commit.replaceHost(to), totalFiles, files.map { it.replaceHost(to) }
-        )
+        private fun CommitWithFiles.replaceHost(to: String) =
+            CommitWithFiles(
+                commit.replaceHost(to),
+                totalFiles,
+                files.map { it.replaceHost(to) },
+            )
 
-        private fun Tag.replaceHost(to: String) = Tag(
-            name, hash, link.replaceHost(to), repository.replaceHost(to)
-        )
+        private fun Tag.replaceHost(to: String) =
+            Tag(
+                name,
+                hash,
+                link.replaceHost(to),
+                repository.replaceHost(to),
+            )
 
-        private fun SearchIssueInRangesResponse.replaceHost(to: String) = SearchIssueInRangesResponse(
-            issueRanges.mapValues { issueRange ->
-                issueRange.value.map {
-                    RepositoryRange(it.sshUrl.replaceHost(to), it.fromHashOrRef, it.fromDate, it.toHashOrRef)
-                }.toSet()
-            }
-        )
+        private fun SearchIssueInRangesResponse.replaceHost(to: String) =
+            SearchIssueInRangesResponse(
+                issueRanges.mapValues { issueRange ->
+                    issueRange.value
+                        .map {
+                            RepositoryRange(it.sshUrl.replaceHost(to), it.fromHashOrRef, it.fromDate, it.toHashOrRef)
+                        }.toSet()
+                },
+            )
 
-        private fun Branch.replaceHost(to: String) = Branch(
-            name, hash, link.replaceHost(to), repository.replaceHost(to)
-        )
+        private fun Branch.replaceHost(to: String) =
+            Branch(
+                name,
+                hash,
+                link.replaceHost(to),
+                repository.replaceHost(to),
+            )
 
-        private fun PullRequest.replaceHost(to: String) = PullRequest(
-            index,
-            title,
-            description,
-            author.replaceHost(to),
-            source,
-            target,
-            assignees.map { it.replaceHost(to) },
-            reviewers.map { PullRequestReviewer(it.user.replaceHost(to), it.approved) },
-            status,
-            createdAt,
-            updatedAt,
-            link.replaceHost(to),
-            repository.replaceHost(to)
-        )
+        private fun PullRequest.replaceHost(to: String) =
+            PullRequest(
+                index,
+                title,
+                description,
+                author.replaceHost(to),
+                source,
+                target,
+                assignees.map { it.replaceHost(to) },
+                reviewers.map { PullRequestReviewer(it.user.replaceHost(to), it.approved) },
+                status,
+                createdAt,
+                updatedAt,
+                link.replaceHost(to),
+                repository.replaceHost(to),
+            )
     }
 }


### PR DESCRIPTION
Adopt the octopusden quality-gates convention for `octopus-vcs-facade` and wire a mandatory `gate/merge` status check.

## What changed
- **Apply plugin:** `org.octopusden.octopus-quality` 2.3.5 at the root; `detekt` + `ktlint` applied per Kotlin subproject (`common`, `client`, `test-common`, `server`/vcs-facade) so Kotlin is actually scanned — avoids a hollow gate.
- **Config:** `octopusQuality { coverage.enabled = false; kotlin.failOnViolation = true; excludeTasks("ft", ":ft:ft") }`.
- **Versions:** `octopus-quality.version=2.3.5`, `detekt.version=1.23.8`, `ktlint.version=14.0.1` declared in `gradle.properties` and consumed by `settings.gradle.kts` pluginManagement.
- **detekt/Kotlin fix:** pinned the `detekt` configuration's Kotlin to `2.0.21` so the Spring `io.spring.dependency-management` BOM does not downgrade detekt's bundled `kotlin-compiler-embeddable` (detekt 1.23.8 rejects the 1.9.22 mismatch).
- **Baselines + format:** ran `ktlintFormat` (ktlint baseline shrank from **1916 → 0** across modules) and generated per-module `detekt-baseline.xml` (**67** violations absorbed: client 5, test-common 23, server 39).
- **Merge gate:** added `merge-gate.yml` (pull_request) → build + quality + security via local `workflow_call` reusables, aggregated by the octopus-base `merge-gate` action → `gate/merge`.
- **ORMS shape:** `build.yml` converted to `push:[main] + workflow_call + workflow_dispatch` (flow-type `hybrid`); added `quality.yml` / `security.yml` (no direct `pull_request`).
- **Pin refs:** all `octopusden/octopus-base/...` reusable-workflow refs bumped to `@v2.3.5`.

## Verification
Verified locally (deps routed to Maven Central via an uncommitted `-I` init script, since the corporate Artifactory mirror is unreachable from the sandbox): `./gradlew clean qualityStatic` is **green**, running `detekt` + `ktlintCheck` across all four Kotlin modules (`:ft` excluded). GitHub Actions resolves dependencies normally and is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
