### PR TITLE
ci: bump octopus-base to 2.5.2 (restores Maven Central releases)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/vcsfacade/vcs-facade/_VER_/vcs-facade-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.5.2
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.2
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.2
     with:
       java-version: '21'
     secrets: inherit


### PR DESCRIPTION
## What

Moves every octopus-base reference to **v2.5.2**, leaving nothing on an older tag:

- all reusable workflow and action refs;
- the **octopus-quality** Gradle convention plugin in `pluginManagement`, where this repository pins one.

## Why

Releases to Maven Central have been failing across the organisation since Sonatype retired OSSRH, and v2.5.x is the fix.

**Publishing.** The temporary compatibility bridge stopped completing the final promotion, so the release job failed while the artifacts sometimes published anyway — a red build and a published version were not mutually exclusive, which is how one component ended up on Maven Central with no git tag. Publishing now goes through the Central Portal API, and a release counts as done only once every artifact is genuinely resolvable on Maven Central: the tag is created after Central confirms, not before. A failed publish is classified in the log — deterministic, transient or resumable — and a run that died after uploading can be finished with the printed deployment id instead of re-uploading a version Maven Central will never let you replace.

**Registration.** The released version used to be resolved by asking "what is the highest version tag in this repository?" — a question unrelated to what the triggering run released. Any stray higher tag silently registers the wrong version, and post-release bookkeeping then records it as the component's latest release. Not hypothetical: on the canary a leftover `v9.9.9` tag hijacked a real `2.2.37` release, so the log recorded 9.9.9 and the stored latest version became 9.9.9, while the real release got no bookkeeping at all. The version is now read from the release that the triggering run stamped with its own id and attempt.

**The internal CI poller.** The script that dispatches a release and watches it used an HTTP library that reflects into JDK internals, which JDK 17+ forbids — so on agents with a newer JDK the release died seconds in, before its first request. It no longer depends on the JDK it runs under.

## Why it's safe

- Everything outside the release path is unchanged code between the two tags: `build`, `quality-gates`, `security-reports`, the `merge-gate` composite action and the `octopus-quality` plugin sources are **byte for byte identical** — the corresponding `git diff v2.4.1..v2.5.2` in octopus-base is empty. No analysis behaviour changes, existing baselines stay valid, and the merge gate behaves exactly as today. Those refs move only so this repository stops running a mixed set of pins.
- Nothing here touches sources, build logic or baselines.

## Verification behind v2.5.2

- **octopus-test `2.2.37`** — a full release from the internal CI: Portal deployment reached `PUBLISHED`, the artifact was confirmed resolvable on Maven Central, the tag was created, the release was registered and post-processing ran.
- **octopus-base `2.5.2`** — released through the same path, with consumer verification against octopus-test before publishing, and both published coordinates confirmed on Maven Central afterwards.
- Already adopted and merged by octopus-test, components-registry-service and api-gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, release, quality, security, and merge-validation workflows.
  * Improved consistency and maintainability across project checks and delivery processes.
  * No changes to application functionality, user-facing behavior, workflow triggers, or configuration inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->