### PR TITLE
build: stop publishing the 90 MB vcs-facade service jar to Maven Central, and move octopus-base to v2.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/vcsfacade/client/_VER_/client-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -11,5 +11,5 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
-      artifact-pattern: "octopus/vcsfacade/vcs-facade/_VER_/vcs-facade-_VER_.jar"
+      artifact-pattern: "octopus/vcsfacade/client/_VER_/client-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/vcsfacade/client/_VER_/client-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.1
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.1
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.1
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
     with:
       java-version: '21'
     secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,62 @@ allprojects {
     }
 }
 
+// Modules allowed to publish to Maven Central. Allowlisted by project PATH, not name: a path is
+// unique and unambiguous for every project including the root (":"), while names need not be —
+// two modules in different parents can share one, and a name-based check would conflate them.
+// A newly added module is absent from this list, so it defaults to unpublished.
+val centralPublishedProjects = setOf(":client", ":common")
+
+fun centralPublicationPolicyProblems(): List<String> {
+    // allprojects, not subprojects: the root is a publishable project like any other.
+    // Read `publishing` only where maven-publish is applied — the extension is absent otherwise.
+    val actual = allprojects
+        .filter { it.plugins.hasPlugin("maven-publish") }
+        .filter { it.extensions.getByType<PublishingExtension>().publications.withType<MavenPublication>().isNotEmpty() }
+        .map { it.path }
+        .toSet()
+    return if (actual == centralPublishedProjects) {
+        emptyList()
+    } else {
+        listOf(
+            "Maven Central publication set drifted.\n" +
+                "  allowlisted: ${centralPublishedProjects.sorted()}\n" +
+                "  publishing:  ${actual.sorted()}",
+        )
+    }
+}
+
+// A policy violation must fail its own gate, not every Gradle invocation: a configuration-time
+// throw would break `build`, `test`, `dependencies` and IDE sync the moment anything drifts.
+// The action reads live project state, so it is not configuration-cache compatible; this build
+// does not enable the configuration cache, and neither does the release pipeline that runs it.
+val verifyCentralPublicationPolicy = tasks.register("verifyCentralPublicationPolicy") {
+    group = "verification"
+    description = "Fails if the set of modules publishing to Maven Central drifts from the allowlist."
+    doLast {
+        val problems = centralPublicationPolicyProblems()
+        if (problems.isNotEmpty()) {
+            throw GradleException(problems.joinToString("\n\n"))
+        }
+    }
+}
+
+// Gate every route to a Maven repository, not just the lifecycle tasks CI happens to call:
+// `AbstractPublishToMaven` covers the per-publication leaf tasks
+// (publishMavenPublicationToSonatypeRepository / …ToMavenLocal), which would otherwise bypass the
+// guard when invoked directly. `publishToSonatype` and `publish` are aggregates of a different
+// type, so they are matched by name — and by name rather than by forcing them into existence,
+// since `publish` only exists where maven-publish is applied.
+gradle.projectsEvaluated {
+    allprojects {
+        tasks.withType<AbstractPublishToMaven>().configureEach {
+            dependsOn(verifyCentralPublicationPolicy)
+        }
+        tasks.matching { it.name in setOf("publishToSonatype", "publish", "publishToMavenLocal") }
+            .configureEach { dependsOn(verifyCentralPublicationPolicy) }
+    }
+}
+
 nexusPublishing {
     repositories {
         sonatype {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ octopus-oc-template.version=2.0.7
 
 # Octopus quality-gates convention plugin + Kotlin static-analysis tools.
 # Versions live here (single source of truth), consumed by settings.gradle.kts pluginManagement.
-octopus-quality.version=2.6.1
+octopus-quality.version=2.6.2
 detekt.version=1.23.8
 ktlint.version=14.0.1
 #

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ octopus-oc-template.version=2.0.7
 
 # Octopus quality-gates convention plugin + Kotlin static-analysis tools.
 # Versions live here (single source of truth), consumed by settings.gradle.kts pluginManagement.
-octopus-quality.version=2.4.1
+octopus-quality.version=2.6.1
 detekt.version=1.23.8
 ktlint.version=14.0.1
 #

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -7,46 +7,11 @@ plugins {
     id("com.avast.gradle.docker-compose")
     id("com.bmuschko.docker-spring-boot-application")
     id("org.octopusden.octopus.oc-template")
-    `maven-publish`
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("bootJar") {
-            artifact(tasks.getByName("bootJar"))
-            from(components["java"])
-            pom {
-                name.set(project.name)
-                description.set("Octopus module: ${project.name}")
-                url.set("https://github.com/octopusden/octopus-vcs-facade.git")
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/kzaporozhtsev/octopus-vcs-facade.git")
-                    connection.set("scm:git://github.com/octopusden/octopus-vcs-facade.git")
-                }
-                developers {
-                    developer {
-                        id.set("octopus")
-                        name.set("octopus")
-                    }
-                }
-            }
-        }
-    }
-}
-
-signing {
-    isRequired = project.ext["signingRequired"] as Boolean
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["bootJar"])
-}
+// This module is a deployable service: its artifact is the docker image built from `bootJar`,
+// not a Maven dependency. It therefore declares no Maven publication — see the
+// `centralPublishedProjects` allowlist in the root build script.
 
 fun String.getExt() = project.ext[this] as String
 


### PR DESCRIPTION
> **Retargeted to octopus-base v2.6.2** after this text was first written. Verified before retargeting: the release workflow's `workflow_call` input set is identical between v2.6.1 and v2.6.2, the publication guard step is untouched, and the `octopus-quality` plugin sources do not move — so the verification recorded below still applies. Local verification was re-run at v2.6.2.

## What

Two changes that must ship together (see **Why one PR** below):

1. **Stop publishing the `vcs-facade` service jar to Maven Central.** The `:server`
   module (published as `vcs-facade`) declared a `MavenPublication("bootJar")`; its
   deliverable is the docker image built from `bootJar`, not a Maven dependency.
   The publication declaration is removed; the `bootJar` task, the `springBoot`/`docker`
   configuration and the compose/ocTemplate wiring are untouched, so nothing that
   produces the image changed.
2. **Move every `octopus-base` reference to `v2.6.2`** — six workflow/action refs plus
   `octopus-quality.version` in `gradle.properties`. Nothing is left on `v2.4.1`.

## Measured footprint

`measure-central-footprint.py` against repo1, release `3.0.34` (the current
`<release>` for all three coordinates), group `org.octopusden.octopus.vcsfacade`:

| artifact | files | bytes | heaviest file | decision |
|---|---:|---:|---|---|
| `vcs-facade` | 60 | 90 820 209 | `vcs-facade-3.0.34.jar` — 90 470 670 B (Spring Boot fat jar) | **dropped** |
| `common` | 50 | 86 161 | `common-3.0.34.jar` — 64 104 B | kept |
| `client` | 50 | 43 369 | `client-3.0.34.jar` — 23 762 B | kept |

- **before:** 160 files / 90 949 739 B (**90.95 MB**) per release
- **after:** 100 files / 129 530 B (**129.5 KB**) per release
- **saved:** −60 files / −90 820 209 B (**−90.82 MB**, 99.86%) per release

Release cadence for this repository is roughly one release per month
(6 tags between 2026-01 and 2026-05), so the monthly saving is of the same order.

"After" is arithmetic, not a re-run: repo1 keeps every version forever, so
`vcs-facade/3.0.34/` stays visible. The proof is the **next** release having no
`vcs-facade/<new-version>/` directory at all.

For scale: the org's free-tier monthly **Release Size** allowance is 78 MB
(as recorded in octopusden/octopus-base#163). This one artifact exceeded the whole
organisation's monthly allowance on its own, every release.

## Dropped, with the evidence it is unconsumed

`org.octopusden.octopus.vcsfacade:vcs-facade`:

- **No Maven consumer anywhere in the org.** Across every `build.gradle[.kts]`,
  `settings.gradle[.kts]`, `*.properties`, `*.toml` and `pom.xml` in the org checkout
  (excluding this repository and its sibling worktrees), the only reference to the
  `org.octopusden.octopus.vcsfacade` group is
  `octopus-sonar-automation/build.gradle.kts:23` → `…vcsfacade:client`. Zero hits for
  `vcs-facade`.
- **No metarunner channel.** This repository has no `.teamcity/` directory and no
  `metarunners/` anywhere — confirmed against `origin/main` with
  `git ls-tree -r --name-only origin/main | grep -iE 'teamcity|metarunner'` (empty).
- **No URL-download channel.** No occurrence of `repo1.maven.org` in any script,
  build file or manifest in this repository, and no file in the org checkout fetches
  a `vcs-facade` jar by URL.
- **No install docs to invalidate.** The README documents build prerequisites and
  properties only; it never mentions Maven Central or a coordinate. Nothing in the
  repository claims the service jar is published, so the staleness sweep found nothing
  to correct beyond the build script itself (which now carries a comment saying why the
  module publishes nothing).
- **Not a distribution channel that needs replacing.** The deliverable is the docker
  image `ghcr.io/octopusden/vcs-facade:<version>`, pushed by the same release job.
  Unlike a CLI, dropping the jar removes no install path a user had.
- **The one real consumer of the coordinate was our own CI**, and it is repointed —
  see below.

## Kept on purpose

- **`client`** — consumed by `octopus-sonar-automation`
  (`build.gradle.kts:23`, version pinned in its `gradle.properties`). 43 KB.
- **`common`** — has **zero direct consumers**, and is kept anyway: `client`
  declares `api(project(":common"))`, so the *published*
  `client-3.0.34.pom` lists `org.octopusden.octopus.vcsfacade:common` at
  `compile` scope. Dropping it would break dependency resolution for a consumer
  that never names it. 86 KB — not worth the risk, and not where the overage is.

## `check-and-register.yml` repointed

The workflow polled
`octopus/vcsfacade/vcs-facade/_VER_/vcs-facade-_VER_.jar`, which stops existing after
this change — the job would poll 45 × 2 min for an artifact that never appears and then
fail. It now polls
`octopus/vcsfacade/client/_VER_/client-_VER_.jar`, which keeps the
"wait until it is genuinely resolvable on Central" gate instead of deleting it.

Verified both paths resolve today at the same release version (`3.0.34`), so the new
one is a like-for-like substitution:

```
GET …/org/octopusden/octopus/vcsfacade/client/3.0.34/client-3.0.34.jar      → HTTP 200
GET …/org/octopusden/octopus/vcsfacade/vcs-facade/3.0.34/vcs-facade-3.0.34.jar → HTTP 200
```

## Regression guard

A publication-surface reduction has no test, so it silently regresses the next time
someone edits a build script. The root build now carries an **allowlist of project
paths** plus a `verifyCentralPublicationPolicy` **task** (`group = verification`),
wired as a dependency of `publishToSonatype`, `publish`, `publishToMavenLocal` and every
`AbstractPublishToMaven` leaf task.

Design points that are deliberate:

- **A task, not a `gradle.projectsEvaluated` throw.** A policy problem must fail its own
  gate; a configuration-time throw would break `build`, `test`, `dependencies` and IDE
  sync the moment anything drifts.
- **Allowlist, not denylist.** A newly added module is absent from the list, so it
  defaults to unpublished — the safe direction. And the expectation is compared against
  the allowlist itself, not against a set derived from it, so the check is not
  tautological.
- **Project *paths*, not names**, and `allprojects`, not `subprojects`: the root project
  is a publishable project like any other, and two modules can share a simple name.
- `publishing` is read only where `maven-publish` is applied — this repository declares
  publishing per module, so the extension is genuinely absent elsewhere.

The allowlist is `[":client", ":common"]`. Every other project in the build, and why it is
excluded — the branch is at `origin/main` exactly, so nothing appeared on `main` after it
was cut:

| project | why not published |
|---|---|
| `:` (root) | aggregator; applies no `maven-publish` and declares no publication |
| `:vcs-facade` (`:server`) | the deployable — this PR's change; ships as a docker image |
| `:test-common` | internal test fixtures; never applied `maven-publish`, never on Central |
| `:ft` | functional-test harness; never applied `maven-publish`, never on Central |

## Why one PR, and why `v2.6.2`

From `octopus-base` **v2.6.0** the shared release workflow runs a guard
("Guard against publishing fat jars to Maven Central") that fails the release *before
upload* when a published artifact carries an `-all` classifier, contains `BOOT-INF/`, or
exceeds `max-central-artifact-mb` (default 8). It is gated on `publish-to-nexus`, which
**defaults to `true`** — and this repository keeps publishing `client`/`common`, so the
guard does run here.

Splitting the two changes creates an ordering hazard with a late, expensive failure mode:
bump first and the next release fails on the 90 MB `vcs-facade` jar, and only at release
time. Combined, the ordering cannot be got wrong.

**No `fat-jar-publication-allowlist` entry is needed.** After the change the publication
set is `client` (23 KB jar) and `common` (64 KB jar): no `-all` classifier, no
`BOOT-INF/`, nothing near 8 MB. `max-central-artifact-mb` is left at its default —
raising it would weaken the guard for every artifact to accommodate one, which is the
wrong trade.

### The bump is byte-safe for everything except the release path

`git diff v2.4.1..v2.6.2 -- gradle-quality-plugin/` in `octopus-base` touches exactly one
file — `OctopusQualityPluginFunctionalTest.kt` (+28/−15). No production code of the
quality plugin changed between the two tags, so the committed `detekt-baseline.xml` /
`ktlint-baseline.xml` files stay valid and the gate behaves as today. Neither baseline
references a build script, so removing the publication block shifts no baselined line
numbers either.

Verified `v2.6.2` exists as a tag in `octopus-base`, and that `octopus-quality` `2.6.2` is
published on Central for both coordinates the plugin resolution needs —
`org.octopusden.octopus:octopus-quality-plugin` and the
`org.octopusden.octopus-quality:org.octopusden.octopus-quality.gradle.plugin` marker.

`v2.6.2` was tagged while this PR was being prepared. It is deliberately **not** adopted
here: `v2.6.2` is the version the rest of this cleanup rollout is pinned to and the one
whose release-guard behaviour was verified locally against this branch. Moving to `v2.6.2`
is a separate, mechanical follow-up once it has the same mileage.

## Supersedes #94

#94 bumps the same references to `v2.5.2` and touches only the six workflow files — it
misses `octopus-quality.version` in `gradle.properties`, which its own description says
it moves, so merging it would leave the repository straddling two versions of the shared
CI. This PR moves all seven references to `v2.6.2` and carries the cleanup the v2.6.x
guard requires. **#94 should be closed in favour of this PR** (left open here rather than
closed unilaterally).

## Verification

Locally, on this branch:

- **`./gradlew clean build -x :vcs-facade:test` — BUILD SUCCESSFUL** (72 actionable
  tasks, all executed). One exclusion, and it is not related to this change:
  `:vcs-facade:test` is an infra-bound integration test that `dockerCompose.isRequiredBy`
  wires onto a gitea + opensearch compose stack. On this host the stack came up, but the
  test's `@BeforeAll` hung for 27 minutes inside a JGit `git push` into the gitea
  container (`BasePackPushConnection.readStatusReport` waiting on a `git-receive-pack`
  response that gitea logged as completed); the run was killed. That path is untouched by
  this PR — no source, no test, no compose file, and no docker wiring changes — and CI
  runs it in its own environment. **`ktlintCheck` and `detekt` ran and passed** as part of
  `check`, for every module including `:vcs-facade`; neither baseline references a build
  script, so no baseline needed regeneration and none was touched.
- `./gradlew verifyCentralPublicationPolicy` — **passes**, and was proven **RED then
  GREEN** rather than only green (full outputs posted as the first comment on this PR).
- `./gradlew publishToMavenLocal --dry-run` — the publication set is exactly
  `:client` and `:common`; `:vcs-facade` contributes no `publish*`/`sign*` task, and
  `:verifyCentralPublicationPolicy` runs first in the graph:
  ```
  :verifyCentralPublicationPolicy SKIPPED
  …
  :client:signMavenPublication SKIPPED
  :client:publishMavenPublicationToMavenLocal SKIPPED
  :client:publishToMavenLocal SKIPPED
  :common:signMavenPublication SKIPPED
  :common:publishMavenPublicationToMavenLocal SKIPPED
  :common:publishToMavenLocal SKIPPED
  ```
- `measure-central-footprint.py --from-gradle` against this branch — asks Gradle what it
  really publishes rather than guessing: **2 coordinates, 100 files, 0.12 MB**.
  ```
  coordinates derived from Gradle (2):
      org.octopusden.octopus.vcsfacade:client
      org.octopusden.octopus.vcsfacade:common
  per release: files=100  size=0.12 MB
  ```
- **The release guard was run locally against this branch**, using its own steps as they stood at
  `common-java-gradle-release.yml@v2.6.1` — byte-identical to v2.6.2's guard step, so the result carries
  over; stated this way because it is a claim about what was actually executed — `publishToMavenLocal -Pnexus=true
  -Dmaven.repo.local=<tmp>` with the same no-signing init script, then its inspection
  script verbatim:
  ```
  Inspected 6 artifact(s) that would be published to Maven Central (size limit 8 MB):
    client      client-<ver>-javadoc.jar    0.00 MB
    client      client-<ver>-sources.jar    0.01 MB
    client      client-<ver>.jar            0.02 MB
    common      common-<ver>-javadoc.jar    0.00 MB
    common      common-<ver>-sources.jar    0.01 MB
    common      common-<ver>.jar            0.06 MB

  Publication set is fit for Maven Central.
  ```
- Central paths for the new `artifact-pattern` checked with real HTTP requests (above).

Only CI can verify:

- that the v2.6.2 release workflow's fat-jar guard passes on a real release (it runs
  `./gradlew publishToMavenLocal -Pnexus=true` on the runner and inspects the result);
- that `check-and-register.yml` resolves `client-<newver>.jar` on the next release;
- the quality/security/build reusable workflows at their new ref.

**No QA deployment.** The diff removes a *publication declaration* only; the `bootJar`
task and the docker-image wiring are unchanged, so a runtime smoke would exercise nothing
this change touched.

Reviewed before opening by two independent passes that did not write the change — one
Claude, one Codex — and re-run after the fixups. Findings addressed: the guard comment
about project paths was reworded, a note added that the task action reads live project
state and so is not configuration-cache compatible (this build does not enable it), and
three overstated claims in this description were corrected (the free-tier size limit is
78 MB, not 80; "byte-identical image" softened to what was actually verified; the plugin
coordinates named precisely). Neither pass raised a P1 or P2.

## No `.teamcity/`

Confirmed explicitly: this repository has no `.teamcity` directory and no TeamCity DSL
files on `origin/main`, so there are no `artifactRules` naming the removed artifact and
no TC command line to re-check.

Related: octopusden/octopus-base#163

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release**
  * Updated build, quality, security, merge, and release automation to newer shared workflow tooling.
  * Improved artifact registration to support the current client JAR naming and location.

* **Publishing**
  * Added verification to ensure only approved modules are published to Maven Central.
  * Removed Maven publication and signing for the deployable server component.

* **Maintenance**
  * Updated project quality tooling to the latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

