### PR TITLE
ci: move octopus-base to v2.7.0 and adopt the shared publication policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/vcsfacade/client/_VER_/client-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
     with:
       java-version: '21'
     secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,26 @@ plugins {
 }
 
 octopusQuality {
+    // Regression guard on what this repository publishes to Maven Central, provided by the
+    // shared policy from octopus-base v2.7.0 — this repository used to hand-roll a path-based
+    // version of the same check (see git history), which is why it is deleted in this same
+    // commit: the plugin registers a task named `verifyCentralPublicationPolicy`, and two tasks
+    // of one name fail configuration.
+    //
+    // Unlike a single-module repository, the project PATH here is a meaningful part of the
+    // identity: :client and :common each declare their own unconditional `publishing {}` block,
+    // so the guard's real job is catching a THIRD module (:server, :test-common, :ft) gaining a
+    // publication it should not have — not distinguishing what :client/:common publish from one
+    // another.
+    publication {
+        enforceCentralPublications.set(true)
+        centralPublications.set(
+            setOf(
+                ":client|maven|org.octopusden.octopus.vcsfacade:client|[jar, jar:javadoc, jar:sources]",
+                ":common|maven|org.octopusden.octopus.vcsfacade:common|[jar, jar:javadoc, jar:sources]",
+            ),
+        )
+    }
     // Repo has no coverage tool / no unit-test coverage target — disable coverage verification.
     coverage {
         enabled.set(false)
@@ -47,62 +67,6 @@ allprojects {
     group = "org.octopusden.octopus.vcsfacade"
     if (version == "unspecified") {
         version = defaultVersion
-    }
-}
-
-// Modules allowed to publish to Maven Central. Allowlisted by project PATH, not name: a path is
-// unique and unambiguous for every project including the root (":"), while names need not be —
-// two modules in different parents can share one, and a name-based check would conflate them.
-// A newly added module is absent from this list, so it defaults to unpublished.
-val centralPublishedProjects = setOf(":client", ":common")
-
-fun centralPublicationPolicyProblems(): List<String> {
-    // allprojects, not subprojects: the root is a publishable project like any other.
-    // Read `publishing` only where maven-publish is applied — the extension is absent otherwise.
-    val actual = allprojects
-        .filter { it.plugins.hasPlugin("maven-publish") }
-        .filter { it.extensions.getByType<PublishingExtension>().publications.withType<MavenPublication>().isNotEmpty() }
-        .map { it.path }
-        .toSet()
-    return if (actual == centralPublishedProjects) {
-        emptyList()
-    } else {
-        listOf(
-            "Maven Central publication set drifted.\n" +
-                "  allowlisted: ${centralPublishedProjects.sorted()}\n" +
-                "  publishing:  ${actual.sorted()}",
-        )
-    }
-}
-
-// A policy violation must fail its own gate, not every Gradle invocation: a configuration-time
-// throw would break `build`, `test`, `dependencies` and IDE sync the moment anything drifts.
-// The action reads live project state, so it is not configuration-cache compatible; this build
-// does not enable the configuration cache, and neither does the release pipeline that runs it.
-val verifyCentralPublicationPolicy = tasks.register("verifyCentralPublicationPolicy") {
-    group = "verification"
-    description = "Fails if the set of modules publishing to Maven Central drifts from the allowlist."
-    doLast {
-        val problems = centralPublicationPolicyProblems()
-        if (problems.isNotEmpty()) {
-            throw GradleException(problems.joinToString("\n\n"))
-        }
-    }
-}
-
-// Gate every route to a Maven repository, not just the lifecycle tasks CI happens to call:
-// `AbstractPublishToMaven` covers the per-publication leaf tasks
-// (publishMavenPublicationToSonatypeRepository / …ToMavenLocal), which would otherwise bypass the
-// guard when invoked directly. `publishToSonatype` and `publish` are aggregates of a different
-// type, so they are matched by name — and by name rather than by forcing them into existence,
-// since `publish` only exists where maven-publish is applied.
-gradle.projectsEvaluated {
-    allprojects {
-        tasks.withType<AbstractPublishToMaven>().configureEach {
-            dependsOn(verifyCentralPublicationPolicy)
-        }
-        tasks.matching { it.name in setOf("publishToSonatype", "publish", "publishToMavenLocal") }
-            .configureEach { dependsOn(verifyCentralPublicationPolicy) }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ octopus-oc-template.version=2.0.7
 
 # Octopus quality-gates convention plugin + Kotlin static-analysis tools.
 # Versions live here (single source of truth), consumed by settings.gradle.kts pluginManagement.
-octopus-quality.version=2.6.2
+octopus-quality.version=2.7.0
 detekt.version=1.23.8
 ktlint.version=14.0.1
 #

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 // This module is a deployable service: its artifact is the docker image built from `bootJar`,
 // not a Maven dependency. It therefore declares no Maven publication — see the
-// `centralPublishedProjects` allowlist in the root build script.
+// `octopusQuality { publication { centralPublications } }` declaration in the root build script.
 
 fun String.getExt() = project.ext[this] as String
 


### PR DESCRIPTION
## What

Two changes that must land in the same commit:

- all six `octopus-base` refs and the inline `octopus-quality.version` in `gradle.properties` move to **v2.7.0**;
- the hand-rolled `verifyCentralPublicationPolicy` in the root `build.gradle.kts` (project-path allowlist, ~55 lines) is **deleted** and replaced by `octopusQuality { publication { ... } }`, which v2.7.0 provides.

## Why the two cannot be split

octopus-base v2.7.0's quality plugin registers a task named exactly `verifyCentralPublicationPolicy`. With the local task definition still present, bumping the plugin version first and removing the local copy in a follow-up would leave both active at once and fail configuration. This is not tidy-up that can follow later.

## This repository's old guard was not a tautology

Unlike a single-module repository, the project **path** here was a meaningful part of the identity the old guard checked: `:client` and `:common` each declare their own unconditional `publishing {}` block (see `client/build.gradle.kts`, `common/build.gradle.kts`), so the allowlist `{":client", ":common"}` was a real comparison target — it would catch a publication newly appearing on `:server`, `:test-common`, or `:ft`, none of which have one today. So this PR is a **consolidation onto shared code**, not a defect fix — the local guard worked correctly, it is being replaced because the plugin now provides the same thing centrally.

Also fixes the stale comment in `server/build.gradle.kts` that named the now-deleted `centralPublishedProjects` allowlist, pointing it at the new `octopusQuality { publication { centralPublications } }` declaration instead.

## Where the identity strings came from

Re-derived from the build itself, not copied from a plan: declared an intentionally wrong set (`["NOPE-CLIENT", "NOPE-COMMON"]`), ran the task, and read what it reported as the actual `publishing:` set. The real identities are:

```
:client|maven|org.octopusden.octopus.vcsfacade:client|[jar, jar:javadoc, jar:sources]
:common|maven|org.octopusden.octopus.vcsfacade:common|[jar, jar:javadoc, jar:sources]
```

That is exactly what is declared in this PR.

## Verification (local, against the real v2.7.0 plugin from Maven Central)

- **GREEN** — `./gradlew verifyCentralPublicationPolicy` passes with the declared set.
- **RED** — dropping a single real classifier, `jar:sources`, from `:client`'s signature while
  leaving everything else untouched fails the task:
  ```
  Maven Central publication set drifted.
    declared:   [:client|maven|org.octopusden.octopus.vcsfacade:client|[jar, jar:javadoc], :common|…|[jar, jar:javadoc, jar:sources]]
    publishing: [:client|maven|org.octopusden.octopus.vcsfacade:client|[jar, jar:javadoc, jar:sources], :common|…|[jar, jar:javadoc, jar:sources]]
  ```
  restoring the file returns to GREEN.

  This replaces a weaker RED this PR originally offered, which corrupted the declared set to
  `["NOPE-CLIENT", "NOPE-COMMON"]`. That did fail the task, but it only demonstrated that two
  different sets compare unequal — it did not show the guard catching a realistic near-miss.
  Since the whole reason for the composite identity is detecting a changed *artifact signature*,
  which the previous path-only guard could not see at all, the near-miss is the case worth
  evidencing. Found in review.
- `./gradlew check --dry-run` schedules `verifyCentralPublicationPolicy` **exactly once**.
- `./gradlew ktlintCheck ktlintKotlinScriptCheck --rerun-tasks` — green across all five modules (`client`, `common`, `test-common`, `ft`, `vcs-facade`/`server`). Checked explicitly after a sibling PR reached CI red on ktlint from a change that only verified the policy task.
- `./gradlew build -x test -x ft -x :ft:ft -x dockerBuildImage -x composeUp -x composeDown -x qualityCoverage` — **BUILD SUCCESSFUL**. Along the way, `:client:validatePublications` and `:common:validatePublications` (both provided by the v2.7.0 plugin) each report "1 publication(s) ... passed Maven Central checks".

## Not verified here

Docker build/compose tasks and the `test`/`ft` suites need Docker and cannot run on this machine — excluded from the `build` invocation above rather than assumed to pass. The release path itself is unchanged by this PR (only the pinned ref moves).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Quality**
  * Updated shared build, quality, security, release, and merge-gate tooling to version 2.7.0.
  * Improved publication validation and enforcement for supported project components.
  * Updated the project’s quality tooling configuration to version 2.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
