### PR TITLE
ci: move octopus-base to v2.7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/vcsfacade/client/_VER_/client-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.0
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.1
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.1
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.1
     with:
       java-version: '21'
     secrets: inherit

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ octopus-oc-template.version=2.0.7
 
 # Octopus quality-gates convention plugin + Kotlin static-analysis tools.
 # Versions live here (single source of truth), consumed by settings.gradle.kts pluginManagement.
-octopus-quality.version=2.7.0
+octopus-quality.version=2.7.1
 detekt.version=1.23.8
 ktlint.version=14.0.1
 #


### PR DESCRIPTION
## What

Moves every pinned `octopus-base` reference from **v2.7.0** to **v2.7.1**, plus the
`octopus-quality` convention-plugin version so this repository does not straddle two versions of
shared CI.

## Why

v2.7.1 fixes a read-after-write race in the release workflows. A release could publish its
artifacts, create its tag, and then fail with:

```
tag vX.Y.Z doesn't exist in the repo ..., aborting due to --verify-tag flag
```

leaving a **half-release**: artifacts published and immutable, tag created at the right commit, no
GitHub release, and registration skipped. It cannot be recovered by re-dispatching the release,
because the version is already published — the recovery is GitHub's *re-run failed jobs* on the
same run, which adopts the existing tag and attaches the release.

`gh release create --verify-tag` resolves the tag through its own GraphQL
`repository.ref(qualifiedName:)` lookup, and that read can miss a ref created milliseconds
earlier. v2.7.1 waits for exactly that lookup to see the tag, on both the fresh-tag and the
tag-adoption path, in the Gradle and Maven release workflows.

Three occurrences are on record, **two of them on v2.7.0 itself**, in two different repositories:
api-gateway v2.0.19, dms-ui v3.0.11 (never repaired), dms-ui v3.0.12. Every repository pinned at
v2.6.2 or later is exposed, which is why this is being rolled out rather than left to the next
release.

Details: octopusden/octopus-base#194.

## Scope

Mechanical. v2.7.1 contains only that fix and its tests, so nothing about this repository's build,
publication set or quality gates changes.

Comments in `build.gradle.kts` that read "from octopus-base v2.7.0" are deliberately left alone:
they record **when the shared publication guard was introduced**, which this bump does not change.
Only text naming the version actually pinned was updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build, quality, security, merge, registration, and release automation to the latest 2.7.1 workflow standards.
  * Updated the project’s quality version to 2.7.1.
  * These maintenance updates improve consistency and reliability across automated validation and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->